### PR TITLE
Fix nsnet2 failure

### DIFF
--- a/nsnet2/index.html
+++ b/nsnet2/index.html
@@ -66,7 +66,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
     <script src="https://webmachinelearning.github.io/webnn-polyfill/dist/webnn-polyfill.js"></script>
     <script src="./libs/numpy.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.8.5"> </script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@3.3.0"> </script>
     <script type="module">
       import {main} from './main.js';
       window.onload = function() {


### PR DESCRIPTION
Align the tf.js version with webnn-polyfill update https://github.com/webmachinelearning/webnn-polyfill/pull/36

@Honry, PTAL. Thanks!