### PR TITLE
Support reusing code of object detection

### DIFF
--- a/object_detection/index.html
+++ b/object_detection/index.html
@@ -118,6 +118,14 @@
       </div>
     </div>
   </div>
+  <script>
+    // This workaround is to fix jquery loading issue in electron.
+    // Refer to https://stackoverflow.com/questions/32621988/electron-jquery-is-not-defined.
+    if (typeof module === "object") {
+      window.tempModule = module;
+      module = undefined;
+    }
+  </script>
   <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
     integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
     crossorigin="anonymous"></script>
@@ -128,6 +136,13 @@
     integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV"
     crossorigin="anonymous"></script>
   <script src="https://webmachinelearning.github.io/webnn-polyfill/dist/webnn-polyfill.js"></script>
+  <script id="tf" src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@latest/dist/tf.min.js" 
+    integrity="sha256-B72Do2A4yC67Y3aXueG3wQXWYjtr5RlI1D2jYDJJYsw=" 
+    crossorigin="anonymous"></script>
+  <script>
+    // To restore module after loading 3rd-party libraries.
+    if (window.tempModule) module = window.tempModule;
+  </script>
   <script type="module">
     import { main } from './main.js';
     window.onload = function () {

--- a/object_detection/main.js
+++ b/object_detection/main.js
@@ -9,6 +9,7 @@ import {getInputTensor, getMedianValue, sizeOfShape} from '../common/utils.js';
 import * as Yolo2Decoder from './libs/yolo2Decoder.js';
 import * as SsdDecoder from './libs/ssdDecoder.js';
 
+const tf = document.getElementById('tf');
 const imgElement = document.getElementById('feedElement');
 imgElement.src = './images/test.jpg';
 const camElement = document.getElementById('feedMediaElement');
@@ -132,7 +133,6 @@ async function drawOutput(inputElement, outputs, labels) {
     // Transpose 'nchw' output to 'nhwc' for postprocessing
     let outputBuffer = outputs.output;
     if (layout === 'nchw') {
-      const tf = navigator.ml.createContext().tf;
       const a =
           tf.tensor(outputBuffer, netInstance.outputDimensions, 'float32');
       const b = tf.transpose(a, [0, 2, 3, 1]);


### PR DESCRIPTION
PTAL @Honry . I try to introduce the `tfjs` from the html file directly, instead of using it from [navigator.ml.createContext().tf](https://github.com/webmachinelearning/webnn-samples/blob/47fee7fb56e88d1bcdb7f46e8f2ea9d29ced5c7b/object_detection/main.js#L135). However, it may take more warning logs in `tfjs`. Other modifications are similar are those in the PR [#49](https://github.com/webmachinelearning/webnn-samples/pull/49).