### PR TITLE
Fixed unexpected error during model switch

### DIFF
--- a/common/css/style.css
+++ b/common/css/style.css
@@ -46,15 +46,20 @@
 
 .loading-page {
   width: 100%;
-  width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
+  position:absolute;
+  top: 0;
+  left: 0;
+  background: #c0bfbf55;
+  z-index: 1000;
 }
 
 .loading-page .counter {
   text-align: center;
-  width: 100%;
+  width: 70%;
 }
 
 .loading-page .counter p {

--- a/image_classification/index.html
+++ b/image_classification/index.html
@@ -30,7 +30,7 @@
         <div class="btn-group-toggle" data-toggle="buttons" id="modelBtns">
           <label class="mr-3">Model: </label>
           <label class="btn btn-outline-info btn-sm mr-2 active">
-            <input type="radio" name="model" id="mobilenet" autocomplete="off" checked>MobileNet V2
+            <input type="radio" name="model" id="mobilenet" autocomplete="off">MobileNet V2
           </label>
           <label class="btn btn-outline-info btn-sm mr-2">
             <input type="radio" name="model" id="squeezenet" autocomplete="off">SqueezeNet
@@ -69,6 +69,10 @@
         </div>
       </div>
     </div>
+    <div class='tab-content text-center mt-5 col-sm' id='hint'>
+      <h2 class="text-uppercase text-warning">No model selected</h2>
+      <p class="font-weight-lighter">Please select model and layout then click 'Predict' button to start prediction.</p>
+    </div>
     <div class='tab-content clearfix row'>
       <div class='tab-pane text-center active col-sm' id='imagetab'>
         <div class='icdisplay'>
@@ -76,7 +80,7 @@
             <div class='row'>
               <div class='col bt-3 mb-3' style='display: flex;'>
                 <div id='div-photos' style='margin: auto; display: flex;' title='Original image'>
-                  <img id='feedElement' hidden crossorigin='anonymous' class='img-fluid' alt='Responsive image' src=''>
+                  <img id='feedElement' hidden crossorigin='anonymous' class='img-fluid' alt='Responsive image'>
                   <canvas id='inputCanvas'></canvas>
                 </div>
               </div>
@@ -172,12 +176,7 @@
     // To restore module after loading 3rd-party libraries.
     if (window.tempModule) module = window.tempModule;
   </script>
-  <script type="module">
-    import { main } from './main.js';
-    window.onload = function () {
-      main();
-    }
-  </script>
+  <script type="module" src='./main.js'></script>
 </body>
 
 </html>

--- a/image_classification/index.html
+++ b/image_classification/index.html
@@ -71,7 +71,7 @@
     </div>
     <div class='tab-content text-center mt-5 col-sm' id='hint'>
       <h2 class="text-uppercase text-warning">No model selected</h2>
-      <p class="font-weight-lighter">Please select model and layout then click 'Predict' button to start prediction.</p>
+      <p class="font-weight-lighter">Please select model and layout to start prediction.</p>
     </div>
     <div class='tab-content clearfix row'>
       <div class='tab-pane text-center active col-sm' id='imagetab'>

--- a/object_detection/index.html
+++ b/object_detection/index.html
@@ -30,7 +30,7 @@
         <div class="btn-group-toggle" data-toggle="buttons" id="modelBtns">
           <label class="mr-3">Model: </label>
           <label class="btn btn-outline-info btn-sm mr-2 active">
-            <input type="radio" name="model" id="tinyyolov2" autocomplete="off" checked>Tiny Yolo V2
+            <input type="radio" name="model" id="tinyyolov2" autocomplete="off">Tiny Yolo V2
           </label>
           <label class="btn btn-outline-info btn-sm mr-2">
             <input type="radio" name="model" id="ssdmobilenetv1" autocomplete="off">SSD MobileNet V1
@@ -66,6 +66,10 @@
         </div>
       </div>
     </div>
+    <div class='tab-content text-center mt-5 col-sm' id='hint'>
+      <h2 class="text-uppercase text-warning">No model selected</h2>
+      <p class="font-weight-lighter">Please select model and layout then click 'Predict' button to start prediction.</p>
+    </div>
     <div class='shoulddisplay tab-content clearfix' style='display: none;'>
       <ul class="list-inline list-pipe text-center">
         <li class="list-inline-item">
@@ -90,7 +94,7 @@
             <div class='row'>
               <div class='col bt-3 mb-3' style='display: flex;'>
                 <div id='div-photos' style='margin: auto; display: flex;' title='Original image'>
-                  <img id='feedElement' hidden crossorigin='anonymous' class='img-fluid' alt='Responsive image' src=''>
+                  <img id='feedElement' hidden crossorigin='anonymous' class='img-fluid' alt='Responsive image'>
                 </div>
               </div>
             </div>
@@ -128,12 +132,7 @@
     integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV"
     crossorigin="anonymous"></script>
   <script src="https://webmachinelearning.github.io/webnn-polyfill/dist/webnn-polyfill.js"></script>
-  <script type="module">
-    import { main } from './main.js';
-    window.onload = function () {
-      main();
-    }
-  </script>
+  <script type="module" src='./main.js'></script>
 </body>
 
 </html>

--- a/object_detection/index.html
+++ b/object_detection/index.html
@@ -68,7 +68,7 @@
     </div>
     <div class='tab-content text-center mt-5 col-sm' id='hint'>
       <h2 class="text-uppercase text-warning">No model selected</h2>
-      <p class="font-weight-lighter">Please select model and layout then click 'Predict' button to start prediction.</p>
+      <p class="font-weight-lighter">Please select model and layout to start prediction.</p>
     </div>
     <div class='shoulddisplay tab-content clearfix' style='display: none;'>
       <ul class="list-inline list-pipe text-center">

--- a/object_detection/main.js
+++ b/object_detection/main.js
@@ -12,10 +12,10 @@ import * as SsdDecoder from './libs/ssdDecoder.js';
 const imgElement = document.getElementById('feedElement');
 imgElement.src = './images/test.jpg';
 const camElement = document.getElementById('feedMediaElement');
-let modelName = 'tinyyolov2';
+let modelName = '';
 let layout = 'nchw';
 let instanceType = modelName + layout;
-let shouldStopFrame = false;
+let rafReq;
 let isFirstTimeLoad = true;
 let inputType = 'image';
 let netInstance = null;
@@ -39,19 +39,19 @@ $(document).ready(() => {
 
 $('#modelBtns .btn').on('change', async (e) => {
   modelName = $(e.target).attr('id');
-  shouldStopFrame = true;
+  if (inputType === 'camera') cancelAnimationFrame(rafReq);
   await main();
 });
 
 $('#layoutBtns .btn').on('change', async (e) => {
   layout = $(e.target).attr('id');
-  shouldStopFrame = true;
+  if (inputType === 'camera') cancelAnimationFrame(rafReq);
   await main();
 });
 
 // Click trigger to do inference with <img> element
 $('#img').click(async () => {
-  shouldStopFrame = true;
+  if (inputType === 'camera') cancelAnimationFrame(rafReq);
   if (stream !== null) {
     stopCamera();
   }
@@ -63,13 +63,14 @@ $('#img').click(async () => {
 $('#imageFile').change((e) => {
   const files = e.target.files;
   if (files.length > 0) {
-    $('#feedElement').on('load', async () => {
-      await main();
-    });
     $('#feedElement').removeAttr('height');
     $('#feedElement').removeAttr('width');
     imgElement.src = URL.createObjectURL(files[0]);
   }
+});
+
+$('#feedElement').on('load', async () => {
+  await main();
 });
 
 // Click trigger to do inference with <video> media element
@@ -107,9 +108,7 @@ async function renderCamStream() {
   camElement.height = camElement.videoHeight;
   showPerfResult();
   await drawOutput(camElement, outputs, labels);
-  if (!shouldStopFrame) {
-    requestAnimationFrame(renderCamStream);
-  }
+  rafReq = requestAnimationFrame(renderCamStream);
 }
 
 async function drawOutput(inputElement, outputs, labels) {
@@ -179,9 +178,10 @@ function addWarning(msg) {
   container.insertBefore(div, container.childNodes[0]);
 }
 
-export async function main() {
+async function main() {
   try {
-    $('input[type="radio"]').attr('disabled', true);
+    if (modelName === '') return;
+    if (isFirstTimeLoad) $('#hint').hide();
     let start;
     // Set 'numRuns' param to run inference multiple times
     const params = new URLSearchParams(location.search);
@@ -258,14 +258,12 @@ export async function main() {
     } else if (inputType === 'camera') {
       await getMediaStream();
       camElement.srcObject = stream;
-      shouldStopFrame = false;
       camElement.onloadedmediadata = await renderCamStream();
       await showProgressComponent('done', 'done', 'done');
       readyShowResultComponents();
     } else {
       throw Error(`Unknown inputType ${inputType}`);
     }
-    $('input[type="radio"]').attr('disabled', false);
   } catch (error) {
     console.log(error);
     addWarning(error.message);

--- a/style_transfer/index.html
+++ b/style_transfer/index.html
@@ -30,8 +30,8 @@
           src='./images/style-images/starrynight.jpg' title='The starry night'></div>
       <div class='gallery-item'><img class='gallery-image' id='self-portrait'
           src='./images/style-images/self-portrait.jpg' title='Self-Portrait' /></div>
-      <div class='gallery-item'><img class='gallery-image' id='bedroom' src='./images/style-images/bedroom.jpg'
-          title='Vincent`s Bedroom in Arles' /></div>
+      <div class='gallery-item'><img class='gallery-image' id='bedroom'
+          src='./images/style-images/bedroom.jpg' title='Vincent`s Bedroom in Arles' /></div>
       <div class='gallery-item'><img class='gallery-image' id='sunflowers-bew'
           src='./images/style-images/Sunflowers-Bew.jpg' title='“Sunflowers” (1889)' /></div>
       <div class='gallery-item'><img class='gallery-image' id='red-vineyards'
@@ -85,7 +85,7 @@
             <div class='row'>
               <div class='col bt-3 mb-3' style='display: flex;'>
                 <div id='div-photos' style='margin: auto; display: flex;' title='Original image'>
-                  <img id='feedElement' hidden crossorigin='anonymous' class='img-fluid' alt='Responsive image' src=''>
+                  <img id='feedElement' hidden crossorigin='anonymous' class='img-fluid' alt='Responsive image'>
                   <canvas id='inputCanvas'></canvas>
                 </div>
               </div>


### PR DESCRIPTION
When switch model before last inference done, error: `cannot read property * of null` will be thrown.

This is because the model instance is changed suddenly when doing load/build/compute operation. To avoid this, I added a overlay to the model loading ui thus user couldn't interrupt the operations.

Besides, make first time loading with no model selected by default, to help user easily choose expected model to experience.