### PR TITLE
Use fused activation of conv2d and batchNorm

### DIFF
--- a/image_classification/resnet50v2_nchw.js
+++ b/image_classification/resnet50v2_nchw.js
@@ -48,12 +48,11 @@ export class ResNet50V2Nchw {
     const bias = await buildConstantByNpy(this.builder_, biasName);
     const mean = await buildConstantByNpy(this.builder_, meanName);
     const variance = await buildConstantByNpy(this.builder_, varName);
-    const batchNorm = this.builder_.batchNormalization(
-        input, mean, variance, {scale: scale, bias: bias});
+    const options = {scale: scale, bias: bias};
     if (relu) {
-      return this.builder_.relu(batchNorm);
+      options.activation = this.builder_.relu();
     }
-    return batchNorm;
+    return this.builder_.batchNormalization(input, mean, variance, options);
   }
 
   async buildGemm_(input, name) {

--- a/image_classification/squeezenet_nchw.js
+++ b/image_classification/squeezenet_nchw.js
@@ -19,15 +19,15 @@ export class SqueezeNetNchw {
     this.outputDimensions = [1, 1000];
   }
 
-  async buildConv_(input, name, options = undefined) {
+  async buildConv_(input, name, options = {}) {
     const prefix = this.weightsUrl_ + 'squeezenet0_' + name;
     const weightsName = prefix + '_weight.npy';
     const weights = await buildConstantByNpy(this.builder_, weightsName);
     const biasName = prefix + '_bias.npy';
     const bias = await buildConstantByNpy(this.builder_, biasName);
-    return this.builder_.relu(this.builder_.add(
-        this.builder_.conv2d(input, weights, options),
-        this.builder_.reshape(bias, [1, -1, 1, 1])));
+    options.bias = bias;
+    options.activation = this.builder_.relu();
+    return this.builder_.conv2d(input, weights, options);
   }
 
   async buildFire_(input, convName, conv1x1Name, conv3x3Name) {

--- a/image_classification/squeezenet_nhwc.js
+++ b/image_classification/squeezenet_nhwc.js
@@ -18,21 +18,17 @@ export class SqueezeNetNhwc {
     this.outputDimensions = [1, 1001];
   }
 
-  async buildConv_(input, name, options = undefined) {
+  async buildConv_(input, name, options = {}) {
     const prefix = this.weightsUrl_ + name;
     const weightsName = prefix + '_kernel.npy';
     const weights = await buildConstantByNpy(this.builder_, weightsName);
     const biasName = prefix + '_Conv2D_bias.npy';
     const bias = await buildConstantByNpy(this.builder_, biasName);
-    if (options !== undefined) {
-      options.inputLayout = 'nhwc';
-      options.filterLayout = 'ohwi';
-    } else {
-      options = {inputLayout: 'nhwc', filterLayout: 'ohwi'};
-    }
-    return this.builder_.relu(this.builder_.add(
-        this.builder_.conv2d(input, weights, options),
-        this.builder_.reshape(bias, [1, 1, 1, -1])));
+    options.inputLayout = 'nhwc';
+    options.filterLayout = 'ohwi';
+    options.bias = bias;
+    options.activation = this.builder_.relu();
+    return this.builder_.conv2d(input, weights, options);
   }
 
   async buildFire_(input, name) {

--- a/object_detection/ssd_mobilenetv1_nhwc.js
+++ b/object_detection/ssd_mobilenetv1_nhwc.js
@@ -68,18 +68,15 @@ ${nameArray[1]}_BatchNorm_batchnorm`;
     if (nameArray[0].includes('depthwise')) {
       options.filterLayout = 'ihwo';
     }
-    const add = this.builder_.add(
-        this.builder_.conv2d(input, weights, options),
-        this.builder_.reshape(bias, [1, 1, 1, -1]));
+    options.bias = bias;
     if (relu6) {
-      return this.builder_.clamp(
-          add,
-          {
-            minValue: this.builder_.constant(0.),
-            maxValue: this.builder_.constant(6.0),
-          });
+      // implement `relu6` by `clamp` of  WebNN API
+      const clampOptions = {};
+      clampOptions.minValue = this.builder_.constant(0);
+      clampOptions.maxValue = this.builder_.constant(6);
+      options.activation = this.builder_.clamp(clampOptions);
     }
-    return add;
+    return this.builder_.conv2d(input, weights, options);
   }
 
   async load() {


### PR DESCRIPTION
fix #74

There are performance boosts of mobilenet-based models when running on webnn-polyfill, by fusing `relu6` (implement by `clamp`) into `conv2d`. For example:

| model | backend | speedup |
|----|----|-----|
| mobilenetv2_nhwc | wasm | 8.9X |
| mobilenetv2_nhwc | webgl | 1.3X |
| mobilenetv2_nchw | wasm | 2.9X |
| mobilenetv2_nchw | webgl | 1.2X |
| ssd_mobilenetv1_nhwc | wasm | 4.7X |
| ssd_mobilenetv1_nhwc | webgl | 1.14X |
| ssd_mobilenetv1_nchw | wasm | 2.4X |
| ssd_mobilenetv1_nchw | webgl | 1.1X |
| deeplabv3_nhwc | wasm | 5.7X |
| deeplabv3_nchw | wasm | 2X |

@Honry , please take a look. cc @pyu10055 