### PR TITLE
Update the code of RNNoise for node example.

### DIFF
--- a/rnnoise/index.html
+++ b/rnnoise/index.html
@@ -16,11 +16,11 @@
         <div class="col-md-8">
           <div class="btn-group-toggle" data-toggle="buttons" id="deviceBtns">
             <span class='mr-3'>Device</span>
-            <label class="btn btn-outline-info mr-2">
-              <input type="radio" name="layout" id="cpu" autocomplete="off">CPU
+            <label class="btn btn-outline-info mr-2 active">
+              <input type="radio" name="layout" id="cpu" autocomplete="off" checked>CPU
             </label>
-            <label class="btn btn-outline-info active">
-              <input type="radio" name="layout" id="gpu" autocomplete="off" checked>GPU
+            <label class="btn btn-outline-info">
+              <input type="radio" name="layout" id="gpu" autocomplete="off">GPU
             </label>
           </div>
         </div>
@@ -79,12 +79,24 @@
       </div>
     </div>
     <script src="../sw.js"></script>
+    <script>
+      // This workaround is to fix jquery loading issue in electron.
+      // Refer to https://stackoverflow.com/questions/32621988/electron-jquery-is-not-defined.
+      if (typeof module === "object") {
+        window.tempModule = module;
+        module = undefined;
+      }
+    </script>
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
     <script src="https://webmachinelearning.github.io/webnn-polyfill/dist/webnn-polyfill.js" crossorigin="anonymous"></script>
     <script type="module" src="./rnnoise.js"></script>
     <script type="module" src="./processer.js"></script>
+    <script>
+      // To restore module after loading 3rd-party libraries.
+      if (window.tempModule) module = window.tempModule;
+    </script>
     <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/rnnoise/main.js
+++ b/rnnoise/main.js
@@ -8,7 +8,9 @@ const frameSize = 480;
 const gainsSize = 22;
 const weightsUrl = '../test-data/models/rnnoise/weights/';
 const rnnoise = new RNNoise(weightsUrl, batchSize, frames);
-let devicePreference = 'gpu';
+// GPU takes a long time to build the model in electron and
+// the CPU backend has better performance for RNNoise model.
+let devicePreference = 'cpu';
 
 $('#deviceBtns .btn').on('change', async (e) => {
   devicePreference = $(e.target).attr('id');


### PR DESCRIPTION
1. Add workaround to fix jquery loading issue in electron.
2. Change default backend from GPU to CPU.

> -   GPU takes a long time to build the model in electron.
> -   CPU backend has better performance for RNNoise model.

@Honry PTAL, thanks!