### PR TITLE
Remove full page cover

### DIFF
--- a/code/index.html
+++ b/code/index.html
@@ -72,7 +72,7 @@
         </div>
       </div>
     </div>
-    <footer class="text-muted text-center text-small">
+    <footer class="text-muted text-center text-small mt-5">
       <p>© 2021 <a href="https://webmachinelearning.github.io/">WebNN API</a></p>
     </footer>
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>

--- a/common/css/style.css
+++ b/common/css/style.css
@@ -46,15 +46,9 @@
 
 .loading-page {
   width: 100%;
-  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  position:absolute;
-  top: 0;
-  left: 0;
-  background: #c0bfbf55;
-  z-index: 1000;
 }
 
 .loading-page .counter {
@@ -489,17 +483,6 @@
   font-size: 0.9rem;
 }
 
-body {
-  position: relative;
-  padding-bottom: 50px;
-}
-
-footer {
-  position: absolute;
-  width: 100%;
-  bottom: 0%;
-}
-
 .btn-outline-info, .btn-outline-secondary {
   font-size: 0.85rem;
   color: #04a1dc;
@@ -544,6 +527,18 @@ footer {
 
 .navbar-dark .navbar-nav .nav-link, .dropdown-toggle {
   color: #fff;
+}
+
+.clickDisabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.styleDisabled {
+  color: #6c757d;
+  background-color: transparent;
+  border-color: #6c757d;
+  opacity: .65;
 }
 
 .dropdown-item:hover {

--- a/common/ui.js
+++ b/common/ui.js
@@ -85,7 +85,8 @@ export function readyShowResultComponents() {
 // Use to disable buttons click during model running and resume them once
 // model running done
 export function handleClick(cssSelectors, disabled = true) {
-  for (let selector of cssSelectors) {
+  /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "selector" }] */
+  for (const selector of cssSelectors) {
     if (disabled) {
       $(selector).addClass('clickDisabled');
       if (selector.startsWith('.btn')) $(selector).addClass('styleDisabled');

--- a/common/ui.js
+++ b/common/ui.js
@@ -72,7 +72,6 @@ export async function showProgressComponent(pm, pb, pi) {
   $('#progressstep').html(p);
   $('.shoulddisplay').hide();
   $('.icdisplay').hide();
-  $('#gallery .gallery-image').off('click');
   await new Promise((res) => setTimeout(res, 100));
 }
 
@@ -80,4 +79,19 @@ export function readyShowResultComponents() {
   $('#progressmodel').hide();
   $('.icdisplay').show();
   $('.shoulddisplay').show();
+}
+
+// Handle buttons click
+// Use to disable buttons click during model running and resume them once
+// model running done
+export function handleClick(cssSelectors, disabled = true) {
+  for (let selector of cssSelectors) {
+    if (disabled) {
+      $(selector).addClass('clickDisabled');
+      if (selector.startsWith('.btn')) $(selector).addClass('styleDisabled');
+    } else {
+      $(selector).removeClass('clickDisabled');
+      if (selector.startsWith('.btn')) $(selector).removeClass('styleDisabled');
+    }
+  }
 }

--- a/image_classification/index.html
+++ b/image_classification/index.html
@@ -91,7 +91,7 @@
         </div>
       </div>
     </div>
-    <ul class='nav nav-tabs nav-justified mb-3' id='ex1' role='tablist'>
+    <ul class='nav nav-tabs nav-justified mb-3' id='tabs' role='tablist'>
       <li class='nav-item' id='img' role='presentation'>
         <a class='nav-link active' data-toggle='tab' href='#imagetab' role='tab' aria-controls='ex3-tabs-1'
           aria-selected='true'>IMAGE</a>
@@ -205,7 +205,7 @@
       </div>
     </div>
   </div>
-  <footer class="text-muted text-center text-small">
+  <footer class="text-muted text-center text-small mt-5">
     <p>© 2021 <a href="https://webmachinelearning.github.io/">WebNN API</a></p>
   </footer>
   <script src="../sw.js"></script>

--- a/lenet/index.html
+++ b/lenet/index.html
@@ -115,7 +115,7 @@
         </div>
       </div>
     </div>
-    <footer class="text-muted text-center text-small">
+    <footer class="text-muted text-center text-small mt-5">
       <p>© 2021 <a href="https://webmachinelearning.github.io/">WebNN API</a></p>
     </footer>
     <script src="../sw.js"></script>

--- a/nsnet2/index.html
+++ b/nsnet2/index.html
@@ -105,7 +105,7 @@
         </div>
       </div>
     </div>
-    <footer class="text-muted text-center text-small">
+    <footer class="text-muted text-center text-small mt-5">
       <p>© 2021 <a href="https://webmachinelearning.github.io/">WebNN API</a></p>
     </footer>
     <script src="../sw.js"></script>

--- a/object_detection/index.html
+++ b/object_detection/index.html
@@ -85,7 +85,7 @@
         </div>
       </div>
     </div>
-    <ul class='nav nav-tabs nav-justified mb-3' id='ex1' role='tablist'>
+    <ul class='nav nav-tabs nav-justified mb-3' id='tabs' role='tablist'>
       <li class='nav-item' id='img' role='presentation'>
         <a class='nav-link active' data-toggle='tab' href='#imagetab' role='tab' aria-controls='ex3-tabs-1'
           aria-selected='true'>IMAGE</a>
@@ -174,7 +174,7 @@
       </div>
     </div>
   </div>
-  <footer class="text-muted text-center text-small">
+  <footer class="text-muted text-center text-small mt-5">
     <p>© 2021 <a href="https://webmachinelearning.github.io/">WebNN API</a></p>
   </footer>
   <script src="../sw.js"></script>

--- a/rnnoise/index.html
+++ b/rnnoise/index.html
@@ -105,7 +105,7 @@
         </div>
       </div>
     </div>
-    <footer class="text-muted text-center text-small">
+    <footer class="text-muted text-center text-small mt-5">
       <p>© 2021 <a href="https://webmachinelearning.github.io/">WebNN API</a></p>
     </footer>
     <script src="../sw.js"></script>

--- a/semantic_segmentation/index.html
+++ b/semantic_segmentation/index.html
@@ -83,7 +83,7 @@
         </div>
       </div>
     </div>
-    <ul class='nav nav-tabs nav-justified mb-3' id='ex1' role='tablist'>
+    <ul class='nav nav-tabs nav-justified mb-3' id='tabs' role='tablist'>
       <li class='nav-item' id='img' role='presentation'>
         <a class='nav-link active' data-toggle='tab' href='#imagetab' role='tab' aria-controls='ex3-tabs-1'
           aria-selected='true'>IMAGE</a>
@@ -212,7 +212,7 @@
       </div>
     </div>
   </div>
-  <footer class="text-muted text-center text-small">
+  <footer class="text-muted text-center text-small mt-5">
     <p>© 2021 <a href="https://webmachinelearning.github.io/">WebNN API</a></p>
   </footer>
   <img id='feedElement' hidden crossorigin='anonymous' src=''>

--- a/style_transfer/fast_style_transfer_net.js
+++ b/style_transfer/fast_style_transfer_net.js
@@ -178,7 +178,7 @@ export class FastStyleTransferNet {
   // Release the constant tensors of a model
   dispose() {
     // dispose() is only available in webnn-polyfill
-    if ('dispose' in this.graph_) {
+    if (this.graph_ !== null && 'dispose' in this.graph_) {
       this.graph_.dispose();
     }
   }

--- a/style_transfer/index.html
+++ b/style_transfer/index.html
@@ -55,7 +55,7 @@
         </div>
       </div>
     </div>
-    <ul class='nav nav-tabs nav-justified mb-3' id='ex1' role='tablist'>
+    <ul class='nav nav-tabs nav-justified mb-3' id='tabs' role='tablist'>
       <li class='nav-item' id='img' role='presentation'>
         <a class='nav-link active' data-toggle='tab' href='#imagetab' role='tab' aria-controls='ex3-tabs-1'
           aria-selected='true'>IMAGE</a>
@@ -190,7 +190,7 @@
       </div>
     </div>
   </div>
-  <footer class="text-muted text-center text-small">
+  <footer class="text-muted text-center text-small mt-5">
     <p>© 2021 <a href="https://webmachinelearning.github.io/">WebNN API</a></p>
   </footer>
   <script src="../sw.js"></script>


### PR DESCRIPTION
Previously when the model is running the full page is
covered and user is not able to operate the page, which
is a not good user experience.

This PR fixes the issue by disable buttons click during
model running to avoid the unexpected errors when switching
the model before last model running is done.