### PR TITLE
network performance - update the model file urls to amazon s3

### DIFF
--- a/image_classification/mobilenet_nchw.js
+++ b/image_classification/mobilenet_nchw.js
@@ -7,7 +7,7 @@ export class MobileNetV2Nchw {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/mobilenetv2_nchw/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/mobilenetv2_nchw/weights/';
     this.inputOptions = {
       mean: [0.485, 0.456, 0.406],
       std: [0.229, 0.224, 0.225],

--- a/image_classification/mobilenet_nhwc.js
+++ b/image_classification/mobilenet_nhwc.js
@@ -9,7 +9,7 @@ export class MobileNetV2Nhwc {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/mobilenetv2_nhwc/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/mobilenetv2_nhwc/weights/';
     this.inputOptions = {
       mean: [127.5, 127.5, 127.5],
       std: [127.5, 127.5, 127.5],

--- a/image_classification/resnet101v2_nhwc.js
+++ b/image_classification/resnet101v2_nhwc.js
@@ -11,7 +11,7 @@ export class ResNet101V2Nhwc {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/resnet101v2_nhwc/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/resnet101v2_nhwc/weights/';
     this.inputOptions = {
       mean: [127.5, 127.5, 127.5],
       std: [127.5, 127.5, 127.5],

--- a/image_classification/resnet50v2_nchw.js
+++ b/image_classification/resnet50v2_nchw.js
@@ -7,7 +7,7 @@ export class ResNet50V2Nchw {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/resnet50v2_nchw/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/resnet50v2_nchw/weights/';
     this.inputOptions = {
       mean: [0.485, 0.456, 0.406],
       std: [0.229, 0.224, 0.225],

--- a/image_classification/resnet50v2_nhwc.js
+++ b/image_classification/resnet50v2_nhwc.js
@@ -11,7 +11,7 @@ export class ResNet50V2Nhwc {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/resnet50v2_nhwc/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/resnet50v2_nhwc/weights/';
     this.inputOptions = {
       mean: [127.5, 127.5, 127.5],
       std: [127.5, 127.5, 127.5],

--- a/image_classification/squeezenet_nchw.js
+++ b/image_classification/squeezenet_nchw.js
@@ -7,7 +7,7 @@ export class SqueezeNetNchw {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/squeezenet1.1_nchw/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/squeezenet1.1_nchw/weights/';
     this.inputOptions = {
       mean: [0.485, 0.456, 0.406],
       std: [0.229, 0.224, 0.225],

--- a/image_classification/squeezenet_nhwc.js
+++ b/image_classification/squeezenet_nhwc.js
@@ -7,7 +7,7 @@ export class SqueezeNetNhwc {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/squeezenet1.0_nhwc/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/squeezenet1.0_nhwc/weights/';
     this.inputOptions = {
       mean: [127.5, 127.5, 127.5],
       std: [127.5, 127.5, 127.5],

--- a/lenet/main.js
+++ b/lenet/main.js
@@ -64,7 +64,7 @@ function clearResult() {
 export async function main() {
   drawNextDigitFromMnist();
   const pen = new Pen(visualCanvas);
-  const weightUrl = '../test-data/models/lenet_nchw/weights/lenet.bin';
+  const weightUrl = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/lenet_nchw/weights/lenet.bin';
   const lenet = new LeNet(weightUrl);
   const [numRuns, powerPreference] = utils.getUrlParams();
   try {

--- a/nsnet2/denoiser.js
+++ b/nsnet2/denoiser.js
@@ -29,7 +29,7 @@ export class Denoiser {
     return new Promise((resolve, reject) => {
       this.log(' - Loading weights... ');
       const start = performance.now();
-      const weightsUrl = '../test-data/models/nsnet2/weights/';
+      const weightsUrl = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/nsnet2/weights/';
       const powerPreference = getUrlParams()[1];
       const contextOptions = {devicePreference};
       if (powerPreference) {

--- a/object_detection/ssd_mobilenetv1_nchw.js
+++ b/object_detection/ssd_mobilenetv1_nchw.js
@@ -8,9 +8,9 @@ export class SsdMobilenetV1Nchw {
     this.model_ = null;
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/ssd_mobilenetv1_nchw/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/ssd_mobilenetv1_nchw/weights/';
     // Shares the same bias files with 'nhwc' layout
-    this.biasUrl_ = '../test-data/models/ssd_mobilenetv1_nhwc/weights/';
+    this.biasUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/ssd_mobilenetv1_nhwc/weights/';
     this.inputOptions = {
       inputLayout: 'nchw',
       labelUrl: './labels/coco_classes.txt',

--- a/object_detection/ssd_mobilenetv1_nhwc.js
+++ b/object_detection/ssd_mobilenetv1_nhwc.js
@@ -8,7 +8,7 @@ export class SsdMobilenetV1Nhwc {
     this.model_ = null;
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/ssd_mobilenetv1_nhwc/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/ssd_mobilenetv1_nhwc/weights/';
     this.inputOptions = {
       inputLayout: 'nhwc',
       labelUrl: './labels/coco_classes.txt',

--- a/object_detection/tiny_yolov2_nchw.js
+++ b/object_detection/tiny_yolov2_nchw.js
@@ -7,7 +7,7 @@ export class TinyYoloV2Nchw {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/tiny_yolov2_nchw/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/tiny_yolov2_nchw/weights/';
     this.inputOptions = {
       inputLayout: 'nchw',
       labelUrl: './labels/pascal_classes.txt',

--- a/object_detection/tiny_yolov2_nhwc.js
+++ b/object_detection/tiny_yolov2_nhwc.js
@@ -7,7 +7,7 @@ export class TinyYoloV2Nhwc {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/tiny_yolov2_nhwc/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/tiny_yolov2_nhwc/weights/';
     this.inputOptions = {
       inputLayout: 'nhwc',
       labelUrl: './labels/pascal_classes.txt',

--- a/rnnoise/main.js
+++ b/rnnoise/main.js
@@ -6,7 +6,7 @@ const batchSize = 1;
 const frames = 100; // Frames is fixed at 100
 const frameSize = 480;
 const gainsSize = 22;
-const weightsUrl = '../test-data/models/rnnoise/weights/';
+const weightsUrl = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/rnnoise/weights/';
 const rnnoise = new RNNoise(weightsUrl, batchSize, frames);
 // GPU takes a long time to build the model in electron and
 // the CPU backend has better performance for RNNoise model.

--- a/semantic_segmentation/deeplabv3_mnv2_nchw.js
+++ b/semantic_segmentation/deeplabv3_mnv2_nchw.js
@@ -9,9 +9,9 @@ export class DeepLabV3MNV2Nchw {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/deeplabv3_mnv2_nchw/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/deeplabv3_mnv2_nchw/weights/';
     // Shares the same bias files with 'nhwc' layout
-    this.biasUrl_ = '../test-data/models/deeplabv3_mnv2_nhwc/weights/';
+    this.biasUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/deeplabv3_mnv2_nhwc/weights/';
     this.inputOptions = {
       mean: [127.5, 127.5, 127.5],
       std: [127.5, 127.5, 127.5],

--- a/semantic_segmentation/deeplabv3_mnv2_nhwc.js
+++ b/semantic_segmentation/deeplabv3_mnv2_nhwc.js
@@ -7,7 +7,7 @@ export class DeepLabV3MNV2Nhwc {
   constructor() {
     this.builder_ = null;
     this.graph_ = null;
-    this.weightsUrl_ = '../test-data/models/deeplabv3_mnv2_nhwc/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/deeplabv3_mnv2_nhwc/weights/';
     this.inputOptions = {
       mean: [127.5, 127.5, 127.5],
       std: [127.5, 127.5, 127.5],

--- a/style_transfer/fast_style_transfer_net.js
+++ b/style_transfer/fast_style_transfer_net.js
@@ -11,7 +11,7 @@ export class FastStyleTransferNet {
     this.graph_ = null;
     this.constPow_ = null;
     this.constAdd_ = null;
-    this.weightsUrl_ = '../test-data/models/fast_style_transfer_nchw/weights/';
+    this.weightsUrl_ = 'https://d3i5xkfad89fac.cloudfront.net/test-data/models/fast_style_transfer_nchw/weights/';
     this.inputOptions = {
       inputDimensions: [1, 3, 540, 540],
       inputLayout: 'nchw',


### PR DESCRIPTION
@Honry I am trying to improve the model loading speed, so updated the model file urls to Amazone S3, please help to merge. 

It spent near 80s to download full mobilenet v2 weight and bias files from github.io in my network environment.
![ms](https://user-images.githubusercontent.com/5017359/163093959-205c0058-6b7d-466a-8bec-22ea31fb5c94.png)
