### PR TITLE
Fixed flaky in model or delegate switch under camera tab

### DIFF
--- a/selfie_segmentation/builtin_delegate_worker.js
+++ b/selfie_segmentation/builtin_delegate_worker.js
@@ -13,6 +13,9 @@ onmessage = async (message) => {
     // Load model or infer depends on the first data
     switch (message.data.action) {
       case 'load': {
+        if (modelRunner) {
+          modelRunner.delete();
+        }
         const loadStart = performance.now();
         const modelPath = message.data.modelPath;
         // Load WASM module and model.


### PR DESCRIPTION
- Check if stream is active to stop last compute when switching the model/delegate
- Delete the tflite model object before a new load
- Make streaming output sync by drawing output with last camera input canvas.