### PR TITLE
Fix object detection sample

### DIFF
--- a/object_detection/main.js
+++ b/object_detection/main.js
@@ -249,7 +249,7 @@ async function main() {
       for (let i = 0; i < numRuns; i++) {
         start = performance.now();
         results = await netInstance.compute(
-            results.inputs.input, outputs);
+            results.inputs.input, results.outputs);
         computeTime = (performance.now() - start).toFixed(2);
         console.log(`  compute time ${i+1}: ${computeTime} ms`);
         computeTimeArray.push(Number(computeTime));

--- a/object_detection/ssd_mobilenetv1_nhwc.js
+++ b/object_detection/ssd_mobilenetv1_nhwc.js
@@ -193,8 +193,10 @@ ${nameArray[1]}_BatchNorm_batchnorm`;
         conv21, ['BoxEncoding', '5', '', '167__cf__170'], false);
     const reshape5 = this.builder_.reshape(conv27, [1, 6, 1, 4]);
     // XNNPACK doesn't support concat inputs size > 4.
-    const concat_reshape0_3 = this.builder_.concat([reshape0, reshape1, reshape2, reshape3], 1);
-    const concat0 = this.builder_.concat([concat_reshape0_3, reshape4, reshape5], 1);
+    const concatReshape0123 = this.builder_.concat(
+        [reshape0, reshape1, reshape2, reshape3], 1);
+    const concat0 = this.builder_.concat(
+        [concatReshape0123, reshape4, reshape5], 1);
 
     // Second concatenation
     const conv28 = await this.buildConv_(
@@ -216,8 +218,10 @@ ${nameArray[1]}_BatchNorm_batchnorm`;
         conv21, ['Class', '5', '', '41__cf__44'], false);
     const reshape11 = this.builder_.reshape(conv33, [1, 6, 91]);
     // XNNPACK doesn't support concat inputs size > 4.
-    const concat_reshape6_9 = this.builder_.concat([reshape6, reshape7, reshape8, reshape9], 1);
-    const concat1 = this.builder_.concat([concat_reshape6_9, reshape10, reshape11], 1);
+    const concatReshape6789 = this.builder_.concat(
+        [reshape6, reshape7, reshape8, reshape9], 1);
+    const concat1 = this.builder_.concat(
+        [concatReshape6789, reshape10, reshape11], 1);
 
     return {'boxes': concat0, 'scores': concat1};
   }

--- a/object_detection/ssd_mobilenetv1_nhwc.js
+++ b/object_detection/ssd_mobilenetv1_nhwc.js
@@ -192,8 +192,9 @@ ${nameArray[1]}_BatchNorm_batchnorm`;
     const conv27 = await this.buildConv_(
         conv21, ['BoxEncoding', '5', '', '167__cf__170'], false);
     const reshape5 = this.builder_.reshape(conv27, [1, 6, 1, 4]);
-    const concat0 = this.builder_.concat(
-        [reshape0, reshape1, reshape2, reshape3, reshape4, reshape5], 1);
+    // XNNPACK doesn't support concat inputs size > 4.
+    const concat_reshape0_3 = this.builder_.concat([reshape0, reshape1, reshape2, reshape3], 1);
+    const concat0 = this.builder_.concat([concat_reshape0_3, reshape4, reshape5], 1);
 
     // Second concatenation
     const conv28 = await this.buildConv_(
@@ -214,8 +215,9 @@ ${nameArray[1]}_BatchNorm_batchnorm`;
     const conv33 = await this.buildConv_(
         conv21, ['Class', '5', '', '41__cf__44'], false);
     const reshape11 = this.builder_.reshape(conv33, [1, 6, 91]);
-    const concat1 = this.builder_.concat(
-        [reshape6, reshape7, reshape8, reshape9, reshape10, reshape11], 1);
+    // XNNPACK doesn't support concat inputs size > 4.
+    const concat_reshape6_9 = this.builder_.concat([reshape6, reshape7, reshape8, reshape9], 1);
+    const concat1 = this.builder_.concat([concat_reshape6_9, reshape10, reshape11], 1);
 
     return {'boxes': concat0, 'scores': concat1};
   }

--- a/object_detection/tiny_yolov2_nhwc.js
+++ b/object_detection/tiny_yolov2_nhwc.js
@@ -32,11 +32,12 @@ export class TinyYoloV2Nhwc {
       autoPad: 'same-upper',
     };
     options.bias = bias;
+    let conv = this.builder_.conv2d(input, weights, options);
     if (leakyRelu) {
-      options.activation =
-          this.builder_.leakyRelu({alpha: 0.10000000149011612});
+      // Fused leakyRelu is not supported by XNNPACK.
+      conv = this.builder_.leakyRelu(conv, {alpha: 0.10000000149011612});
     }
-    return this.builder_.conv2d(input, weights, options);
+    return conv;
   }
 
   async load(contextOptions) {


### PR DESCRIPTION
This PR fixes the object detection samples for Chromium XNNPACK backend. They are:
1. detached output ArrayBufferView issue of main.js
2. fused leakyRelu is not supported issue
3. concat inputs size > 4 is not supported issue

@Honry , PTAL. Thanks!