### PR TITLE
Add a duplicate entry to support new "dataType"

### DIFF
--- a/code/samples/matmul.js
+++ b/code/samples/matmul.js
@@ -3,9 +3,9 @@ const context = await navigator.ml.createContext();
 // The following code multiplies matrix a [3, 4] with matrix b [4, 3]
 // into matrix c [3, 3].
 const builder = new MLGraphBuilder(context);
-const descA = {type: 'float32', dimensions: [3, 4]};
+const descA = {type: 'float32', dataType: 'float32', dimensions: [3, 4]};
 const a = builder.input('a', descA);
-const descB = {type: 'float32', dimensions: [4, 3]};
+const descB = {type: 'float32', dataType: 'float32', dimensions: [4, 3]};
 const bufferB = new Float32Array(sizeOfShape(descB.dimensions)).fill(0.5);
 const b = builder.constant(descB, bufferB);
 const c = builder.matmul(a, b);

--- a/code/samples/mul_add.js
+++ b/code/samples/mul_add.js
@@ -1,4 +1,4 @@
-const operandType = {type: 'float32', dimensions: [2, 2]};
+const operandType = {type: 'float32', dataType: 'float32', dimensions: [2, 2]};
 const context = await navigator.ml.createContext();
 const builder = new MLGraphBuilder(context);
 // 1. Create a computational graph 'C = 0.2 * A + B'.

--- a/code/samples/optional_outputs.js
+++ b/code/samples/optional_outputs.js
@@ -2,12 +2,12 @@ const context = await navigator.ml.createContext();
 
 // Build a graph with two outputs.
 const builder = new MLGraphBuilder(context);
-const descA = {type: 'float32', dimensions: [3, 4]};
+const descA = {type: 'float32', dataType: 'float32', dimensions: [3, 4]};
 const a = builder.input('a', descA);
-const descB = {type: 'float32', dimensions: [4, 3]};
+const descB = {type: 'float32', dataType: 'float32', dimensions: [4, 3]};
 const bufferB = new Float32Array(sizeOfShape(descB.dimensions)).fill(0.5);
 const b = builder.constant(descB, bufferB);
-const descC = {type: 'float32', dimensions: [3, 3]};
+const descC = {type: 'float32', dataType: 'float32', dimensions: [3, 3]};
 const bufferC = new Float32Array(sizeOfShape(descC.dimensions)).fill(1);
 const c = builder.constant(descC, bufferC);
 const d = builder.matmul(a, b);

--- a/code/samples/simple_graph.js
+++ b/code/samples/simple_graph.js
@@ -18,7 +18,7 @@ const TENSOR_SIZE = 8;
 const builder = new MLGraphBuilder(context);
 
 // Create MLOperandDescriptor object.
-const desc = {type: 'float32', dimensions: TENSOR_DIMS};
+const desc = {type: 'float32', dataType: 'float32', dimensions: TENSOR_DIMS};
 
 // constant1 is a constant MLOperand with the value 0.5.
 const constantBuffer1 = new Float32Array(TENSOR_SIZE).fill(0.5);

--- a/common/utils.js
+++ b/common/utils.js
@@ -52,7 +52,7 @@ export async function buildConstantByNpy(builder, url) {
   const dataView = new Uint8Array(npArray.data.buffer);
   const dataView2 = dataView.slice();
   const typedArray = new TypedArrayConstructor(dataView2.buffer);
-  return builder.constant({type, dimensions}, typedArray);
+  return builder.constant({dataType: type, type, dimensions}, typedArray);
 }
 
 // Convert video frame to a canvas element

--- a/face_recognition/facenet_nchw.js
+++ b/face_recognition/facenet_nchw.js
@@ -124,8 +124,11 @@ export class FaceNetNchw {
   async load(contextOptions) {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
 
     const poolOptions = {windowDimensions: [3, 3], strides};
 

--- a/face_recognition/facenet_nhwc.js
+++ b/face_recognition/facenet_nhwc.js
@@ -125,8 +125,11 @@ export class FaceNetNhwc {
   async load(contextOptions) {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
 
     const poolOptions = {windowDimensions: [3, 3], strides, layout: 'nhwc'};
 

--- a/facial_landmark_detection/face_landmark_nchw.js
+++ b/facial_landmark_detection/face_landmark_nchw.js
@@ -64,8 +64,11 @@ export class FaceLandmarkNchw {
   async load(contextOptions) {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
 
     const poolOptions =
         {windowDimensions: [2, 2], strides: [2, 2]};

--- a/facial_landmark_detection/face_landmark_nhwc.js
+++ b/facial_landmark_detection/face_landmark_nhwc.js
@@ -65,8 +65,11 @@ export class FaceLandmarkNhwc {
   async load(contextOptions) {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
 
     const poolOptions =
         {windowDimensions: [2, 2], strides: [2, 2], layout: 'nhwc'};

--- a/facial_landmark_detection/ssd_mobilenetv2_face_nchw.js
+++ b/facial_landmark_detection/ssd_mobilenetv2_face_nchw.js
@@ -121,8 +121,11 @@ ${nameArray[1]}`;
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.deviceType_ = contextOptions.deviceType;
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
 
     const bottleneck0 = await this.buildLinearBottleneck_(
         input, '0', false, 32, 'convRelu6');

--- a/facial_landmark_detection/ssd_mobilenetv2_face_nhwc.js
+++ b/facial_landmark_detection/ssd_mobilenetv2_face_nhwc.js
@@ -128,8 +128,11 @@ ${nameArray[1]}`;
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.deviceType_ = contextOptions.deviceType;
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
 
     const bottleneck0 = await this.buildLinearBottleneck_(
         input, '0', false, 32, 'convRelu6');

--- a/image_classification/mobilenet_nchw.js
+++ b/image_classification/mobilenet_nchw.js
@@ -78,8 +78,11 @@ export class MobileNetV2Nchw {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.deviceType_ = contextOptions.deviceType;
     this.builder_ = new MLGraphBuilder(this.context_);
-    const data = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const data = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const conv0 = await this.buildConv_(
         data, '0', true, {padding: [1, 1, 1, 1], strides: [2, 2]});
     const conv1 = await this.buildConv_(

--- a/image_classification/mobilenet_nhwc.js
+++ b/image_classification/mobilenet_nhwc.js
@@ -71,8 +71,11 @@ export class MobileNetV2Nhwc {
     const strides = [2, 2];
     const autoPad = 'same-upper';
     const filterLayout = 'ohwi';
-    const input = this.builder_.input(
-        'input', {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const conv0 = await this.buildConv_(
         input, '90', 'Conv_Conv2D', true, {strides, autoPad, filterLayout});
     const conv1 = await this.buildConv_(

--- a/image_classification/resnet50v2_nchw.js
+++ b/image_classification/resnet50v2_nchw.js
@@ -94,8 +94,11 @@ export class ResNet50V2Nchw {
   async load(contextOptions) {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const data = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const data = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const bn1 = await this.buildBatchNorm_(data, '0', '', false);
     const conv0 = await this.buildConv_(
         bn1, '0', '', {padding: [3, 3, 3, 3], strides: [2, 2]});

--- a/image_classification/resnet50v2_nhwc.js
+++ b/image_classification/resnet50v2_nhwc.js
@@ -98,8 +98,11 @@ export class ResNet50V2Nhwc {
   async load(contextOptions) {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const conv1 = await this.buildConv_(
         input, ['', '', '1'], {strides, padding: [3, 3, 3, 3]}, false);
     const pool = this.builder_.maxPool2d(

--- a/image_classification/squeezenet_nchw.js
+++ b/image_classification/squeezenet_nchw.js
@@ -42,8 +42,11 @@ export class SqueezeNetNchw {
   async load(contextOptions) {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const data = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const data = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const conv0 = await this.buildConv_(data, 'conv0', {strides: [2, 2]});
     const pool0 = this.builder_.maxPool2d(
         conv0, {windowDimensions: [3, 3], strides: [2, 2]});

--- a/image_classification/squeezenet_nhwc.js
+++ b/image_classification/squeezenet_nhwc.js
@@ -45,8 +45,11 @@ export class SqueezeNetNhwc {
     this.builder_ = new MLGraphBuilder(this.context_);
     const strides = [2, 2];
     const layout = 'nhwc';
-    const placeholder = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const placeholder = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const conv1 = await this.buildConv_(
         placeholder, 'conv1', {strides, autoPad: 'same-upper'});
     const maxpool1 = this.builder_.maxPool2d(

--- a/lenet/lenet.js
+++ b/lenet/lenet.js
@@ -21,15 +21,18 @@ export class LeNet {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
     const inputShape = [1, 1, 28, 28];
-    const input =
-        this.builder_.input('input', {type: 'float32', dimensions: inputShape});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: inputShape,
+    });
 
     const conv1FitlerShape = [20, 1, 5, 5];
     let byteOffset = 0;
     const conv1FilterData = new Float32Array(
         arrayBuffer, byteOffset, sizeOfShape(conv1FitlerShape));
     const conv1Filter = this.builder_.constant(
-        {type: 'float32', dimensions: conv1FitlerShape},
+        {type: 'float32', dataType: 'float32', dimensions: conv1FitlerShape},
         conv1FilterData);
     byteOffset +=
         sizeOfShape(conv1FitlerShape) * Float32Array.BYTES_PER_ELEMENT;
@@ -39,7 +42,9 @@ export class LeNet {
     const add1BiasData =
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add1BiasShape));
     const add1Bias = this.builder_.constant(
-        {type: 'float32', dimensions: add1BiasShape}, add1BiasData);
+        {type: 'float32', dataType: 'float32', dimensions: add1BiasShape},
+        add1BiasData,
+    );
     byteOffset += sizeOfShape(add1BiasShape) * Float32Array.BYTES_PER_ELEMENT;
     const add1 = this.builder_.add(conv1, add1Bias);
 
@@ -51,16 +56,17 @@ export class LeNet {
 
     const conv2FilterShape = [50, 20, 5, 5];
     const conv2Filter = this.builder_.constant(
-        {type: 'float32', dimensions: conv2FilterShape},
+        {type: 'float32', dataType: 'float32', dimensions: conv2FilterShape},
         new Float32Array(
-            arrayBuffer, byteOffset, sizeOfShape(conv2FilterShape)));
+            arrayBuffer, byteOffset, sizeOfShape(conv2FilterShape)),
+    );
     byteOffset +=
         sizeOfShape(conv2FilterShape) * Float32Array.BYTES_PER_ELEMENT;
     const conv2 = this.builder_.conv2d(pool1, conv2Filter);
 
     const add2BiasShape = [1, 50, 1, 1];
     const add2Bias = this.builder_.constant(
-        {type: 'float32', dimensions: add2BiasShape},
+        {type: 'float32', dataType: 'float32', dimensions: add2BiasShape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add2BiasShape)));
     byteOffset += sizeOfShape(add2BiasShape) * Float32Array.BYTES_PER_ELEMENT;
     const add2 = this.builder_.add(conv2, add2Bias);
@@ -79,7 +85,7 @@ export class LeNet {
 
     const matmul1Shape = [500, 800];
     const matmul1Weights = this.builder_.constant(
-        {type: 'float32', dimensions: matmul1Shape},
+        {type: 'float32', dataType: 'float32', dimensions: matmul1Shape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(matmul1Shape)));
     byteOffset += sizeOfShape(matmul1Shape) * Float32Array.BYTES_PER_ELEMENT;
     const matmul1WeightsTransposed = this.builder_.transpose(matmul1Weights);
@@ -87,7 +93,7 @@ export class LeNet {
 
     const add3BiasShape = [1, 500];
     const add3Bias = this.builder_.constant(
-        {type: 'float32', dimensions: add3BiasShape},
+        {type: 'float32', dataType: 'float32', dimensions: add3BiasShape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add3BiasShape)));
     byteOffset += sizeOfShape(add3BiasShape) * Float32Array.BYTES_PER_ELEMENT;
     const add3 = this.builder_.add(matmul1, add3Bias);
@@ -99,7 +105,7 @@ export class LeNet {
 
     const matmul2Shape = [10, 500];
     const matmul2Weights = this.builder_.constant(
-        {type: 'float32', dimensions: matmul2Shape},
+        {type: 'float32', dataType: 'float32', dimensions: matmul2Shape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(matmul2Shape)));
     byteOffset += sizeOfShape(matmul2Shape) * Float32Array.BYTES_PER_ELEMENT;
     const matmul2WeightsTransposed = this.builder_.transpose(matmul2Weights);
@@ -107,7 +113,7 @@ export class LeNet {
 
     const add4BiasShape = [1, 10];
     const add4Bias = this.builder_.constant(
-        {type: 'float32', dimensions: add4BiasShape},
+        {type: 'float32', dataType: 'float32', dimensions: add4BiasShape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add4BiasShape)));
     const add4 = this.builder_.add(matmul2, add4Bias);
 

--- a/nsnet2/nsnet2.js
+++ b/nsnet2/nsnet2.js
@@ -36,16 +36,26 @@ export class NSNet2 {
     const weight217 = await buildConstantByNpy(this.builder_, baseUrl + '217.npy');
     const biasFcOut4 = await buildConstantByNpy(this.builder_, baseUrl + 'fc_out_4_bias.npy');
     // Build up the network.
-    const input = this.builder_.input('input', {type: 'float32', dimensions: [batchSize, frames, this.frameSize]});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: [batchSize, frames, this.frameSize],
+    });
     const relu20 = this.builder_.relu(this.builder_.add(this.builder_.matmul(input, weight172), biasFcIn0));
     const transpose31 = this.builder_.transpose(relu20, {permutation: [1, 0, 2]});
-    const initialState92 = this.builder_.input(
-        'initialState92', {type: 'float32', dimensions: [1, batchSize, this.hiddenSize]});
+    const initialState92 = this.builder_.input('initialState92', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: [1, batchSize, this.hiddenSize],
+    });
     const [gru94, gru93] = this.builder_.gru(transpose31, weight192, recurrentWeight193, frames, this.hiddenSize,
         {bias: bias194, recurrentBias: recurrentBias194, initialHiddenState: initialState92, returnSequence: true});
     const squeeze95 = this.builder_.squeeze(gru93, {axes: [1]});
-    const initialState155 = this.builder_.input(
-        'initialState155', {type: 'float32', dimensions: [1, batchSize, this.hiddenSize]});
+    const initialState155 = this.builder_.input('initialState155', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: [1, batchSize, this.hiddenSize],
+    });
     const [gru157, gru156] = this.builder_.gru(squeeze95, weight212, recurrentWeight213, frames, this.hiddenSize,
         {bias: bias214, recurrentBias: recurrentBias214, initialHiddenState: initialState155, returnSequence: true});
     const squeeze158 = this.builder_.squeeze(gru156, {axes: [1]});

--- a/object_detection/ssd_mobilenetv1_nchw.js
+++ b/object_detection/ssd_mobilenetv1_nchw.js
@@ -79,8 +79,11 @@ ${nameArray[1]}_BatchNorm_batchnorm`;
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.deviceType_ = contextOptions.deviceType;
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const strides = [2, 2];
     const conv0 = await this.buildConv_(
         input, ['', '0', '', '165__cf__168'],

--- a/object_detection/ssd_mobilenetv1_nhwc.js
+++ b/object_detection/ssd_mobilenetv1_nhwc.js
@@ -90,8 +90,11 @@ ${nameArray[1]}_BatchNorm_batchnorm`;
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.deviceType_ = contextOptions.deviceType;
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const strides = [2, 2];
     const conv0 = await this.buildConv_(
         input, ['', '0', '', '165__cf__168'], true, {strides});

--- a/object_detection/tiny_yolov2_nchw.js
+++ b/object_detection/tiny_yolov2_nchw.js
@@ -56,13 +56,20 @@ export class TinyYoloV2Nchw {
   async load(contextOptions) {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const image = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const image = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
 
-    const mulScale = this.builder_.constant({type: 'float32',
-      dimensions: [1]}, new Float32Array([0.003921568859368563]));
-    const addBias = this.builder_.constant({type: 'float32',
-      dimensions: [3, 1, 1]}, new Float32Array([0, 0, 0]));
+    const mulScale = this.builder_.constant(
+        {type: 'float32', dataType: 'float32', dimensions: [1]},
+        new Float32Array([0.003921568859368563]),
+    );
+    const addBias = this.builder_.constant(
+        {type: 'float32', dataType: 'float32', dimensions: [3, 1, 1]},
+        new Float32Array([0, 0, 0]),
+    );
     const poolOptions = {
       windowDimensions: [2, 2],
       strides: [2, 2],

--- a/object_detection/tiny_yolov2_nhwc.js
+++ b/object_detection/tiny_yolov2_nhwc.js
@@ -43,8 +43,11 @@ export class TinyYoloV2Nhwc {
   async load(contextOptions) {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
 
     const poolOptions = {
       windowDimensions: [2, 2],

--- a/rnnoise/rnnoise.js
+++ b/rnnoise/rnnoise.js
@@ -51,9 +51,11 @@ export class RNNoise {
     const denoiseOutputBias0 = await buildConstantByNpy(this.builder_,
         this.baseUrl_ + 'denoise_output_bias_0.npy');
     // Build up the network.
-    const input = this.builder_.input(
-        'input', {type: 'float32', dimensions: [this.batchSize_,
-          this.frames_, this.featureSize]});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: [this.batchSize_, this.frames_, this.featureSize],
+    });
     const inputDense0 = this.builder_.matmul(input, inputDenseKernel0);
     const biasedTensorName2 = this.builder_.add(inputDense0, inputDenseBias0);
     const inputDenseTanh0 = this.builder_.tanh(biasedTensorName2);
@@ -67,6 +69,7 @@ export class RNNoise {
         [1, 3 * this.vadGruHiddenSize]);
     const vadGruInitialH = this.builder_.input('vadGruInitialH', {
       type: 'float32',
+      dataType: 'float32',
       dimensions: [1, this.batchSize_, this.vadGruHiddenSize],
     });
     const [vadGruYH, vadGruY] = this.builder_.gru(vadGruX,
@@ -92,8 +95,9 @@ export class RNNoise {
         noiseGruBData,
         [0, 3 * this.noiseGruHiddenSize],
         [1, 3 * this.noiseGruHiddenSize]);
-    const noiseGruInitialH = this.builder_.input( 'noiseGruInitialH', {
+    const noiseGruInitialH = this.builder_.input('noiseGruInitialH', {
       type: 'float32',
+      dataType: 'float32',
       dimensions: [1, this.batchSize_, this.noiseGruHiddenSize],
     });
     const [noiseGruYH, noiseGruY] = this.builder_.gru(noiseGruX,
@@ -121,6 +125,7 @@ export class RNNoise {
         [1, 3 * this.denoiseGruHiddenSize]);
     const denoiseGruInitialH = this.builder_.input('denoiseGruInitialH', {
       type: 'float32',
+      dataType: 'float32',
       dimensions: [1, this.batchSize_, this.denoiseGruHiddenSize],
     });
     const [denoiseGruYH, denoiseGruY] = this.builder_.gru(denoiseGruX,

--- a/semantic_segmentation/deeplabv3_mnv2_nchw.js
+++ b/semantic_segmentation/deeplabv3_mnv2_nchw.js
@@ -95,8 +95,11 @@ export class DeepLabV3MNV2Nchw {
     this.builder_ = new MLGraphBuilder(this.context_);
     const strides = [2, 2];
 
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const conv0 = await this.buildConv_(
         input, ['MobilenetV2_Conv_Conv2D', '', '551'], 'relu6', {strides, padding: [1, 1, 1, 1]});
     const conv1 = await this.buildConv_(

--- a/semantic_segmentation/deeplabv3_mnv2_nhwc.js
+++ b/semantic_segmentation/deeplabv3_mnv2_nhwc.js
@@ -83,8 +83,11 @@ export class DeepLabV3MNV2Nhwc {
     this.deviceType_ = contextOptions.deviceType;
     this.builder_ = new MLGraphBuilder(this.context_);
     const strides = [2, 2];
-    const input = this.builder_.input('input',
-        {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const conv0 = await this.buildConv_(
         input, 'MobilenetV2_Conv_Conv2D', '', true, {strides});
     const conv1 = await this.buildConv_(

--- a/style_transfer/fast_style_transfer_net.js
+++ b/style_transfer/fast_style_transfer_net.js
@@ -91,15 +91,27 @@ export class FastStyleTransferNet {
     const padding1 = [0, 0, 1, 1];
     const padding4 = [0, 0, 4, 4];
     this.constAdd_ = this.builder_.constant(
-        {type: 'float32', dimensions: [1]}, new Float32Array([9.999999717180685e-10]));
+        {type: 'float32', dataType: 'float32', dimensions: [1]},
+        new Float32Array([9.999999717180685e-10]),
+    );
     this.constPow_ = this.builder_.constant(
-        {type: 'float32', dimensions: [1]}, new Float32Array([0.5]));
+        {type: 'float32', dataType: 'float32', dimensions: [1]},
+        new Float32Array([0.5]),
+    );
     const constMul0 = this.builder_.constant(
-        {type: 'float32', dimensions: [1]}, new Float32Array([150]));
+        {type: 'float32', dataType: 'float32', dimensions: [1]},
+        new Float32Array([150]),
+    );
     const constAdd0 = this.builder_.constant(
-        {type: 'float32', dimensions: [1]}, new Float32Array([127.5]));
+        {type: 'float32', dataType: 'float32', dimensions: [1]},
+        new Float32Array([127.5]),
+    );
     // Build up the network.
-    const input = this.builder_.input('input', {type: 'float32', dimensions: this.inputOptions.inputDimensions});
+    const input = this.builder_.input('input', {
+      type: 'float32',
+      dataType: 'float32',
+      dimensions: this.inputOptions.inputDimensions,
+    });
     const conv2D0 = this.builder_.conv2d(this.builder_.pad(input, padding4, padding4, {mode: 'reflection'}), weightConv0);
 
     const add0 = this.buildInstanceNormalization_(conv2D0, variableMul0, variableAdd0);


### PR DESCRIPTION
WebNN spec renames "type" as "dataType" at webmachinelearning/webnn#464, add a duplicate entry for "dataType" in order to workaround the compatibility issue.