### PR TITLE
Refactor the Facial Landmark Detection example to fetch in parallel

### DIFF
--- a/facial_landmark_detection/face_landmark_nchw.js
+++ b/facial_landmark_detection/face_landmark_nchw.js
@@ -16,7 +16,7 @@ export class FaceLandmarkNchw {
   }
 
   async buildMaxPool2d(input, options) {
-    return this.builder_.maxPool2d(await input, options)
+    return this.builder_.maxPool2d(await input, options);
   }
 
   async buildConv_(input, indice) {

--- a/facial_landmark_detection/face_landmark_nchw.js
+++ b/facial_landmark_detection/face_landmark_nchw.js
@@ -15,6 +15,10 @@ export class FaceLandmarkNchw {
     };
   }
 
+  async buildMaxPool2d(input, options) {
+    return this.builder_.maxPool2d(await input, options)
+  }
+
   async buildConv_(input, indice) {
     const prefix = `${this.weightsUrl_}/conv2d`;
     let weightSuffix = '_kernel.npy';
@@ -26,33 +30,33 @@ export class FaceLandmarkNchw {
     }
 
     const weightsName = prefix + weightSuffix;
-    const weights = await buildConstantByNpy(this.builder_, weightsName);
+    const weights = buildConstantByNpy(this.builder_, weightsName);
     const biasName = prefix + biasSuffix;
-    const bias = await buildConstantByNpy(this.builder_, biasName);
+    const bias = buildConstantByNpy(this.builder_, biasName);
     const options = {
-      bias: bias,
+      bias: await bias,
       activation: this.builder_.relu(),
     };
-    return this.builder_.conv2d(input, weights, options);
+    return this.builder_.conv2d(await input, await weights, options);
   }
 
   async buildGemm_(input, namePrefix, relu = false, reshapeSize) {
-    const weights = await buildConstantByNpy(this.builder_,
+    const weights = buildConstantByNpy(this.builder_,
         `${this.weightsUrl_}/${namePrefix}_kernel_transpose.npy`);
-    const bias = await buildConstantByNpy(this.builder_,
+    const bias = buildConstantByNpy(this.builder_,
         `${this.weightsUrl_}/${namePrefix}_MatMul_bias.npy`);
     const options = {
       aTranspose: false,
       bTranspose: true,
-      c: bias,
+      c: await bias,
     };
     let gemm;
     if (reshapeSize !== undefined) {
       gemm = this.builder_.gemm(this.builder_.reshape(
-          this.builder_.transpose(input, {permutation: [0, 2, 3, 1]}),
-          [null, reshapeSize]), weights, options);
+          this.builder_.transpose(await input, {permutation: [0, 2, 3, 1]}),
+          [null, reshapeSize]), await weights, options);
     } else {
-      gemm = this.builder_.gemm(input, weights, options);
+      gemm = this.builder_.gemm(await input, await weights, options);
     }
     if (relu) {
       gemm = this.builder_.relu(gemm);
@@ -73,27 +77,26 @@ export class FaceLandmarkNchw {
     const poolOptions =
         {windowDimensions: [2, 2], strides: [2, 2]};
 
-    const conv0 = await this.buildConv_(input, 0);
-    const pool0 = await this.builder_.maxPool2d(conv0, poolOptions);
+    const conv0 = this.buildConv_(input, 0);
+    const pool0 = this.buildMaxPool2d(conv0, poolOptions);
 
-    const conv1 = await this.buildConv_(pool0, 1);
-    const conv2 = await this.buildConv_(conv1, 2);
-    const pool1 = await this.builder_.maxPool2d(conv2, poolOptions);
+    const conv1 = this.buildConv_(pool0, 1);
+    const conv2 = this.buildConv_(conv1, 2);
+    const pool1 = this.buildMaxPool2d(conv2, poolOptions);
 
-    const conv3 = await this.buildConv_(pool1, 3);
-    const conv4 = await this.buildConv_(conv3, 4);
-    const pool2 = await this.builder_.maxPool2d(conv4, poolOptions);
+    const conv3 = this.buildConv_(pool1, 3);
+    const conv4 = this.buildConv_(conv3, 4);
+    const pool2 = this.buildMaxPool2d(conv4, poolOptions);
 
-    const conv5 = await this.buildConv_(pool2, 5);
-    const conv6 = await this.buildConv_(conv5, 6);
-    const pool3 = await this.builder_.maxPool2d(
-        conv6, {windowDimensions: [2, 2]});
+    const conv5 = this.buildConv_(pool2, 5);
+    const conv6 = this.buildConv_(conv5, 6);
+    const pool3 = this.buildMaxPool2d(conv6, {windowDimensions: [2, 2]});
 
-    const conv7 = await this.buildConv_(pool3, 7);
-    const gemm0 = await this.buildGemm_(conv7, 'dense', true, 6400);
-    const gemm1 = await this.buildGemm_(gemm0, 'logits');
+    const conv7 = this.buildConv_(pool3, 7);
+    const gemm0 = this.buildGemm_(conv7, 'dense', true, 6400);
+    const gemm1 = this.buildGemm_(gemm0, 'logits');
 
-    return gemm1;
+    return await gemm1;
   }
 
   async build(outputOperand) {

--- a/facial_landmark_detection/face_landmark_nhwc.js
+++ b/facial_landmark_detection/face_landmark_nhwc.js
@@ -16,7 +16,7 @@ export class FaceLandmarkNhwc {
   }
 
   async buildMaxPool2d(input, options) {
-    return this.builder_.maxPool2d(await input, options)
+    return this.builder_.maxPool2d(await input, options);
   }
 
   async buildConv_(input, indice) {

--- a/facial_landmark_detection/face_landmark_nhwc.js
+++ b/facial_landmark_detection/face_landmark_nhwc.js
@@ -15,6 +15,10 @@ export class FaceLandmarkNhwc {
     };
   }
 
+  async buildMaxPool2d(input, options) {
+    return this.builder_.maxPool2d(await input, options)
+  }
+
   async buildConv_(input, indice) {
     const prefix = `${this.weightsUrl_}/conv2d`;
     let weightSuffix = '_kernel.npy';
@@ -26,34 +30,34 @@ export class FaceLandmarkNhwc {
     }
 
     const weightsName = prefix + weightSuffix;
-    const weights = await buildConstantByNpy(this.builder_, weightsName);
+    const weights = buildConstantByNpy(this.builder_, weightsName);
     const biasName = prefix + biasSuffix;
-    const bias = await buildConstantByNpy(this.builder_, biasName);
+    const bias = buildConstantByNpy(this.builder_, biasName);
     const options = {
       inputLayout: 'nhwc',
       filterLayout: 'ohwi',
-      bias: bias,
+      bias: await bias,
       activation: this.builder_.relu(),
     };
-    return this.builder_.conv2d(input, weights, options);
+    return this.builder_.conv2d(await input, await weights, options);
   }
 
   async buildFullyConnected_(input, namePrefix, relu = false, reshapeSize) {
-    const weights = await buildConstantByNpy(this.builder_,
+    const weights = buildConstantByNpy(this.builder_,
         `${this.weightsUrl_}/${namePrefix}_kernel_transpose.npy`);
-    const bias = await buildConstantByNpy(this.builder_,
+    const bias = buildConstantByNpy(this.builder_,
         `${this.weightsUrl_}/${namePrefix}_MatMul_bias.npy`);
     const options = {
       aTranspose: false,
       bTranspose: true,
-      c: bias,
+      c: await bias,
     };
     let fc;
     if (reshapeSize !== undefined) {
       fc = this.builder_.gemm(this.builder_.reshape(
-          input, [null, reshapeSize]), weights, options);
+          await input, [null, reshapeSize]), await weights, options);
     } else {
-      fc = this.builder_.gemm(input, weights, options);
+      fc = this.builder_.gemm(await input, await weights, options);
     }
     if (relu) {
       fc = this.builder_.relu(fc);
@@ -74,28 +78,28 @@ export class FaceLandmarkNhwc {
     const poolOptions =
         {windowDimensions: [2, 2], strides: [2, 2], layout: 'nhwc'};
 
-    const conv0 = await this.buildConv_(input, 0);
-    const pool0 = await this.builder_.maxPool2d(conv0, poolOptions);
+    const conv0 = this.buildConv_(input, 0);
+    const pool0 = this.buildMaxPool2d(conv0, poolOptions);
 
-    const conv1 = await this.buildConv_(pool0, 1);
-    const conv2 = await this.buildConv_(conv1, 2);
-    const pool1 = await this.builder_.maxPool2d(conv2, poolOptions);
+    const conv1 = this.buildConv_(pool0, 1);
+    const conv2 = this.buildConv_(conv1, 2);
+    const pool1 = this.buildMaxPool2d(conv2, poolOptions);
 
-    const conv3 = await this.buildConv_(pool1, 3);
-    const conv4 = await this.buildConv_(conv3, 4);
-    const pool2 = await this.builder_.maxPool2d(conv4, poolOptions);
+    const conv3 = this.buildConv_(pool1, 3);
+    const conv4 = this.buildConv_(conv3, 4);
+    const pool2 = this.buildMaxPool2d(conv4, poolOptions);
 
-    const conv5 = await this.buildConv_(pool2, 5);
-    const conv6 = await this.buildConv_(conv5, 6);
-    const pool3 = await this.builder_.maxPool2d(
+    const conv5 = this.buildConv_(pool2, 5);
+    const conv6 = this.buildConv_(conv5, 6);
+    const pool3 = this.buildMaxPool2d(
         conv6, {windowDimensions: [2, 2], layout: 'nhwc'});
 
-    const conv7 = await this.buildConv_(pool3, 7);
-    const fc0 = await this.buildFullyConnected_(
+    const conv7 = this.buildConv_(pool3, 7);
+    const fc0 = this.buildFullyConnected_(
         conv7, 'dense', true, 6400);
-    const fc1 = await this.buildFullyConnected_(fc0, 'logits');
+    const fc1 = this.buildFullyConnected_(fc0, 'logits');
 
-    return fc1;
+    return await fc1;
   }
 
   async build(outputOperand) {

--- a/facial_landmark_detection/main.js
+++ b/facial_landmark_detection/main.js
@@ -260,16 +260,20 @@ async function main() {
         contextOptions['numThreads'] = numThreads;
       }
       start = performance.now();
-      const fdOutputOperand = await fdInstance.load(contextOptions);
-      const fldOutputOperand = await fldInstance.load(contextOptions);
+      const [fdOutputOperand, fldOutputOperand] = await Promise.all([
+          fdInstance.load(contextOptions),
+          fldInstance.load(contextOptions)
+      ]);
       loadTime = (performance.now() - start).toFixed(2);
       console.log(`  done in ${loadTime} ms.`);
       // UI shows model building progress
       await ui.showProgressComponent('done', 'current', 'pending');
       console.log('- Building... ');
       start = performance.now();
-      await fdInstance.build(fdOutputOperand);
-      await fldInstance.build(fldOutputOperand);
+      await Promise.all([
+          fdInstance.build(fdOutputOperand),
+          fldInstance.build(fldOutputOperand)
+      ]);
       buildTime = (performance.now() - start).toFixed(2);
       console.log(`  done in ${buildTime} ms.`);
     }

--- a/facial_landmark_detection/main.js
+++ b/facial_landmark_detection/main.js
@@ -261,8 +261,8 @@ async function main() {
       }
       start = performance.now();
       const [fdOutputOperand, fldOutputOperand] = await Promise.all([
-          fdInstance.load(contextOptions),
-          fldInstance.load(contextOptions)
+        fdInstance.load(contextOptions),
+        fldInstance.load(contextOptions),
       ]);
       loadTime = (performance.now() - start).toFixed(2);
       console.log(`  done in ${loadTime} ms.`);
@@ -271,8 +271,8 @@ async function main() {
       console.log('- Building... ');
       start = performance.now();
       await Promise.all([
-          fdInstance.build(fdOutputOperand),
-          fldInstance.build(fldOutputOperand)
+        fdInstance.build(fdOutputOperand),
+        fldInstance.build(fldOutputOperand),
       ]);
       buildTime = (performance.now() - start).toFixed(2);
       console.log(`  done in ${buildTime} ms.`);

--- a/facial_landmark_detection/ssd_mobilenetv2_face_nchw.js
+++ b/facial_landmark_detection/ssd_mobilenetv2_face_nchw.js
@@ -230,7 +230,7 @@ ${nameArray[1]}`;
       biasAdd24: await biasAdd24,
       biasAdd27: await biasAdd27,
       biasAdd30: await biasAdd30,
-      biasAdd33: await biasAdd33
+      biasAdd33: await biasAdd33,
     };
   }
 

--- a/facial_landmark_detection/ssd_mobilenetv2_face_nchw.js
+++ b/facial_landmark_detection/ssd_mobilenetv2_face_nchw.js
@@ -63,9 +63,9 @@ ${nameArray[1]}`;
     }
 
     const weightsName = prefix + weightSuffix;
-    const weights = await buildConstantByNpy(this.builder_, weightsName);
+    const weights = buildConstantByNpy(this.builder_, weightsName);
     const biasName = prefix + biasSuffix;
-    const bias = await buildConstantByNpy(this.builder_, biasName);
+    const bias = buildConstantByNpy(this.builder_, biasName);
     if (options !== undefined) {
       options.autoPad = 'same-upper';
     } else {
@@ -73,20 +73,20 @@ ${nameArray[1]}`;
         autoPad: 'same-upper',
       };
     }
-    options.bias = bias;
+    options.bias = await bias;
     if (clip) {
       // TODO: Set clamp activation to options once it's supported in
       // WebNN DML backend.
       // Implement `clip` by `clamp` of  WebNN API
       if (this.deviceType_ == 'gpu') {
         return this.builder_.clamp(
-            this.builder_.conv2d(input, weights, options),
+            this.builder_.conv2d(await input, await weights, options),
             {minValue: 0, maxValue: 6});
       } else {
         options.activation = this.builder_.clamp({minValue: 0, maxValue: 6});
       }
     }
-    return this.builder_.conv2d(input, weights, options);
+    return this.builder_.conv2d(await input, await weights, options);
   }
 
   async buildLinearBottleneck_(
@@ -103,17 +103,17 @@ ${nameArray[1]}`;
     const convRelu6Keyword = indice === '0' ?
           'FeatureExtractor_MobilenetV2_Conv' : 'expanded';
 
-    const convRelu6 = await this.buildConv_(
+    const convRelu6 = this.buildConv_(
         input, [convRelu6Keyword, indice], true, convOptions);
-    const dwiseRelu6 = await this.buildConv_(
+    const dwiseRelu6 = this.buildConv_(
         convRelu6, ['expanded_depthwise', indice], true, dwiseOptions);
-    const convLinear = await this.buildConv_(
+    const convLinear = this.buildConv_(
         dwiseRelu6, ['expanded_project', indice], false);
 
     if (shortcut) {
-      return this.builder_.add(input, convLinear);
+      return this.builder_.add(await input, await convLinear);
     }
-    return convLinear;
+    return await convLinear;
   }
 
 
@@ -127,99 +127,111 @@ ${nameArray[1]}`;
       dimensions: this.inputOptions.inputDimensions,
     });
 
-    const bottleneck0 = await this.buildLinearBottleneck_(
+    const bottleneck0 = this.buildLinearBottleneck_(
         input, '0', false, 32, 'convRelu6');
-    const bottleneck1 = await this.buildLinearBottleneck_(
+    const bottleneck1 = this.buildLinearBottleneck_(
         bottleneck0, '1', false, 96, 'dwiseRelu6');
-    const bottleneck2 = await this.buildLinearBottleneck_(
+    const bottleneck2 = this.buildLinearBottleneck_(
         bottleneck1, '2', true, 144);
-    const bottleneck3 = await this.buildLinearBottleneck_(
+    const bottleneck3 = this.buildLinearBottleneck_(
         bottleneck2, '3', false, 144, 'dwiseRelu6');
-    const bottleneck4 = await this.buildLinearBottleneck_(
+    const bottleneck4 = this.buildLinearBottleneck_(
         bottleneck3, '4', true, 192);
-    const bottleneck5 = await this.buildLinearBottleneck_(
+    const bottleneck5 = this.buildLinearBottleneck_(
         bottleneck4, '5', true, 192);
-    const bottleneck6 = await this.buildLinearBottleneck_(
+    const bottleneck6 = this.buildLinearBottleneck_(
         bottleneck5, '6', false, 192, 'dwiseRelu6');
-    const bottleneck7 = await this.buildLinearBottleneck_(
+    const bottleneck7 = this.buildLinearBottleneck_(
         bottleneck6, '7', true, 384);
-    const bottleneck8 = await this.buildLinearBottleneck_(
+    const bottleneck8 = this.buildLinearBottleneck_(
         bottleneck7, '8', true, 384);
-    const bottleneck9 = await this.buildLinearBottleneck_(
+    const bottleneck9 = this.buildLinearBottleneck_(
         bottleneck8, '9', true, 384);
-    const bottleneck10 = await this.buildLinearBottleneck_(
+    const bottleneck10 = this.buildLinearBottleneck_(
         bottleneck9, '10', false, 384);
-    const bottleneck11 = await this.buildLinearBottleneck_(
+    const bottleneck11 = this.buildLinearBottleneck_(
         bottleneck10, '11', true, 576);
-    const bottleneck12 = await this.buildLinearBottleneck_(
+    const bottleneck12 = this.buildLinearBottleneck_(
         bottleneck11, '12', true, 576);
-    const conv13Relu6 = await this.buildConv_(
+    const conv13Relu6 = this.buildConv_(
         bottleneck12, ['expanded', '13']);
-    const dwise13Relu6 = await this.buildConv_(
+    const dwise13Relu6 = this.buildConv_(
         conv13Relu6,
         ['expanded_depthwise', '13'],
         true,
         {groups: 576, strides: [2, 2]});
-    const convLinear13 = await this.buildConv_(
+    const convLinear13 = this.buildConv_(
         dwise13Relu6, ['expanded_project', '13'], false);
 
-    const biasAdd0 = await this.buildConv_(
+    const biasAdd0 = this.buildConv_(
         conv13Relu6, ['BoxEncoding', '0'], false);
-    const biasAdd3 = await this.buildConv_(
+    const biasAdd3 = this.buildConv_(
         conv13Relu6, ['Class', '0'], false);
 
-    const bottleneck14 = await this.buildLinearBottleneck_(
+    const bottleneck14 = this.buildLinearBottleneck_(
         convLinear13, '14', true, 960);
-    const bottleneck15 = await this.buildLinearBottleneck_(
+    const bottleneck15 = this.buildLinearBottleneck_(
         bottleneck14, '15', true, 960);
-    const bottleneck16 = await this.buildLinearBottleneck_(
+    const bottleneck16 = this.buildLinearBottleneck_(
         bottleneck15, '16', false, 960);
 
-    const conv17Relu6 = await this.buildConv_(
+    const conv17Relu6 = this.buildConv_(
         bottleneck16, ['FeatureExtractor_MobilenetV2_Conv_1']);
-    const biasAdd6 = await this.buildConv_(
+    const biasAdd6 = this.buildConv_(
         conv17Relu6, ['BoxEncoding', '1'], false);
-    const biasAdd9 = await this.buildConv_(
+    const biasAdd9 = this.buildConv_(
         conv17Relu6, ['Class', '1'], false);
 
-    const conv18Relu6 = await this.buildConv_(
+    const conv18Relu6 = this.buildConv_(
         conv17Relu6, ['layer_19_1', '2_1x1_256']);
-    const conv19Relu6 = await this.buildConv_(
+    const conv19Relu6 = this.buildConv_(
         conv18Relu6, ['layer_19_2', '2_3x3_s2_512'], true, {strides: [2, 2]});
-    const biasAdd12 = await this.buildConv_(
+    const biasAdd12 = this.buildConv_(
         conv19Relu6, ['BoxEncoding', '2'], false);
-    const biasAdd15 = await this.buildConv_(
+    const biasAdd15 = this.buildConv_(
         conv19Relu6, ['Class', '2'], false);
 
-    const conv20Relu6 = await this.buildConv_(
+    const conv20Relu6 = this.buildConv_(
         conv19Relu6, ['layer_19_1', '3_1x1_128']);
-    const conv21Relu6 = await this.buildConv_(
+    const conv21Relu6 = this.buildConv_(
         conv20Relu6, ['layer_19_2', '3_3x3_s2_256'], true, {strides: [2, 2]});
-    const biasAdd18 = await this.buildConv_(
+    const biasAdd18 = this.buildConv_(
         conv21Relu6, ['BoxEncoding', '3'], false);
-    const biasAdd21 = await this.buildConv_(
+    const biasAdd21 = this.buildConv_(
         conv21Relu6, ['Class', '3'], false);
 
-    const conv22Relu6 = await this.buildConv_(
+    const conv22Relu6 = this.buildConv_(
         conv21Relu6, ['layer_19_1', '4_1x1_128']);
-    const conv23Relu6 = await this.buildConv_(
+    const conv23Relu6 = this.buildConv_(
         conv22Relu6, ['layer_19_2', '4_3x3_s2_256'], true, {strides: [2, 2]});
-    const biasAdd24 = await this.buildConv_(
+    const biasAdd24 = this.buildConv_(
         conv23Relu6, ['BoxEncoding', '4'], false);
-    const biasAdd27 = await this.buildConv_(
+    const biasAdd27 = this.buildConv_(
         conv23Relu6, ['Class', '4'], false);
 
-    const conv24Relu6 = await this.buildConv_(
+    const conv24Relu6 = this.buildConv_(
         conv23Relu6, ['layer_19_1', '5_1x1_64']);
-    const conv25Relu6 = await this.buildConv_(
+    const conv25Relu6 = this.buildConv_(
         conv24Relu6, ['layer_19_2', '5_3x3_s2_128'], true, {strides: [2, 2]});
-    const biasAdd30 = await this.buildConv_(
+    const biasAdd30 = this.buildConv_(
         conv25Relu6, ['BoxEncoding', '5'], false);
-    const biasAdd33 = await this.buildConv_(
+    const biasAdd33 = this.buildConv_(
         conv25Relu6, ['Class', '5'], false);
 
-    return {biasAdd0, biasAdd3, biasAdd6, biasAdd9, biasAdd12, biasAdd15,
-      biasAdd18, biasAdd21, biasAdd24, biasAdd27, biasAdd30, biasAdd33};
+    return {
+      biasAdd0: await biasAdd0,
+      biasAdd3: await biasAdd3,
+      biasAdd6: await biasAdd6,
+      biasAdd9: await biasAdd9,
+      biasAdd12: await biasAdd12,
+      biasAdd15: await biasAdd15,
+      biasAdd18: await biasAdd18,
+      biasAdd21: await biasAdd21,
+      biasAdd24: await biasAdd24,
+      biasAdd27: await biasAdd27,
+      biasAdd30: await biasAdd30,
+      biasAdd33: await biasAdd33
+    };
   }
 
   async build(outputOperand) {

--- a/facial_landmark_detection/ssd_mobilenetv2_face_nhwc.js
+++ b/facial_landmark_detection/ssd_mobilenetv2_face_nhwc.js
@@ -237,7 +237,7 @@ ${nameArray[1]}`;
       biasAdd24: await biasAdd24,
       biasAdd27: await biasAdd27,
       biasAdd30: await biasAdd30,
-      biasAdd33: await biasAdd33
+      biasAdd33: await biasAdd33,
     };
   }
 

--- a/facial_landmark_detection/ssd_mobilenetv2_face_nhwc.js
+++ b/facial_landmark_detection/ssd_mobilenetv2_face_nhwc.js
@@ -63,9 +63,9 @@ ${nameArray[1]}`;
     }
 
     const weightsName = prefix + weightSuffix;
-    const weights = await buildConstantByNpy(this.builder_, weightsName);
+    const weights = buildConstantByNpy(this.builder_, weightsName);
     const biasName = prefix + biasSuffix;
-    const bias = await buildConstantByNpy(this.builder_, biasName);
+    const bias = buildConstantByNpy(this.builder_, biasName);
     if (options !== undefined) {
       options.inputLayout = 'nhwc';
       options.filterLayout = 'ohwi';
@@ -80,20 +80,20 @@ ${nameArray[1]}`;
     if (nameArray[0].includes('depthwise')) {
       options.filterLayout = 'ihwo';
     }
-    options.bias = bias;
+    options.bias = await bias;
     if (relu6) {
       // TODO: Set clamp activation to options once it's supported in
       // WebNN DML backend.
       // Implement `clip` by `clamp` of  WebNN API
       if (this.deviceType_ == 'gpu') {
         return this.builder_.clamp(
-            this.builder_.conv2d(input, weights, options),
+            this.builder_.conv2d(await input, await weights, options),
             {minValue: 0, maxValue: 6});
       } else {
         options.activation = this.builder_.clamp({minValue: 0, maxValue: 6});
       }
     }
-    return this.builder_.conv2d(input, weights, options);
+    return this.builder_.conv2d(await input, await weights, options);
   }
 
   async buildLinearBottleneck_(
@@ -110,17 +110,17 @@ ${nameArray[1]}`;
     const convRelu6Keyword = indice === '0' ?
           'FeatureExtractor_MobilenetV2_Conv' : 'expanded';
 
-    const convRelu6 = await this.buildConv_(
+    const convRelu6 = this.buildConv_(
         input, [convRelu6Keyword, indice], true, convOptions);
-    const dwiseRelu6 = await this.buildConv_(
+    const dwiseRelu6 = this.buildConv_(
         convRelu6, ['expanded_depthwise', indice], true, dwiseOptions);
-    const convLinear = await this.buildConv_(
+    const convLinear = this.buildConv_(
         dwiseRelu6, ['expanded_project', indice], false);
 
     if (shortcut) {
-      return this.builder_.add(input, convLinear);
+      return this.builder_.add(await input, await convLinear);
     }
-    return convLinear;
+    return await convLinear;
   }
 
 
@@ -134,99 +134,111 @@ ${nameArray[1]}`;
       dimensions: this.inputOptions.inputDimensions,
     });
 
-    const bottleneck0 = await this.buildLinearBottleneck_(
+    const bottleneck0 = this.buildLinearBottleneck_(
         input, '0', false, 32, 'convRelu6');
-    const bottleneck1 = await this.buildLinearBottleneck_(
+    const bottleneck1 = this.buildLinearBottleneck_(
         bottleneck0, '1', false, 96, 'dwiseRelu6');
-    const bottleneck2 = await this.buildLinearBottleneck_(
+    const bottleneck2 = this.buildLinearBottleneck_(
         bottleneck1, '2', true, 144);
-    const bottleneck3 = await this.buildLinearBottleneck_(
+    const bottleneck3 = this.buildLinearBottleneck_(
         bottleneck2, '3', false, 144, 'dwiseRelu6');
-    const bottleneck4 = await this.buildLinearBottleneck_(
+    const bottleneck4 = this.buildLinearBottleneck_(
         bottleneck3, '4', true, 192);
-    const bottleneck5 = await this.buildLinearBottleneck_(
+    const bottleneck5 = this.buildLinearBottleneck_(
         bottleneck4, '5', true, 192);
-    const bottleneck6 = await this.buildLinearBottleneck_(
+    const bottleneck6 = this.buildLinearBottleneck_(
         bottleneck5, '6', false, 192, 'dwiseRelu6');
-    const bottleneck7 = await this.buildLinearBottleneck_(
+    const bottleneck7 = this.buildLinearBottleneck_(
         bottleneck6, '7', true, 384);
-    const bottleneck8 = await this.buildLinearBottleneck_(
+    const bottleneck8 = this.buildLinearBottleneck_(
         bottleneck7, '8', true, 384);
-    const bottleneck9 = await this.buildLinearBottleneck_(
+    const bottleneck9 = this.buildLinearBottleneck_(
         bottleneck8, '9', true, 384);
-    const bottleneck10 = await this.buildLinearBottleneck_(
+    const bottleneck10 = this.buildLinearBottleneck_(
         bottleneck9, '10', false, 384);
-    const bottleneck11 = await this.buildLinearBottleneck_(
+    const bottleneck11 = this.buildLinearBottleneck_(
         bottleneck10, '11', true, 576);
-    const bottleneck12 = await this.buildLinearBottleneck_(
+    const bottleneck12 = this.buildLinearBottleneck_(
         bottleneck11, '12', true, 576);
-    const conv13Relu6 = await this.buildConv_(
+    const conv13Relu6 = this.buildConv_(
         bottleneck12, ['expanded', '13']);
-    const dwise13Relu6 = await this.buildConv_(
+    const dwise13Relu6 = this.buildConv_(
         conv13Relu6,
         ['expanded_depthwise', '13'],
         true,
         {groups: 576, strides: [2, 2]});
-    const convLinear13 = await this.buildConv_(
+    const convLinear13 = this.buildConv_(
         dwise13Relu6, ['expanded_project', '13'], false);
 
-    const biasAdd0 = await this.buildConv_(
+    const biasAdd0 = this.buildConv_(
         conv13Relu6, ['BoxEncoding', '0'], false);
-    const biasAdd3 = await this.buildConv_(
+    const biasAdd3 = this.buildConv_(
         conv13Relu6, ['Class', '0'], false);
 
-    const bottleneck14 = await this.buildLinearBottleneck_(
+    const bottleneck14 = this.buildLinearBottleneck_(
         convLinear13, '14', true, 960);
-    const bottleneck15 = await this.buildLinearBottleneck_(
+    const bottleneck15 = this.buildLinearBottleneck_(
         bottleneck14, '15', true, 960);
-    const bottleneck16 = await this.buildLinearBottleneck_(
+    const bottleneck16 = this.buildLinearBottleneck_(
         bottleneck15, '16', false, 960);
 
-    const conv17Relu6 = await this.buildConv_(
+    const conv17Relu6 = this.buildConv_(
         bottleneck16, ['FeatureExtractor_MobilenetV2_Conv_1']);
-    const biasAdd6 = await this.buildConv_(
+    const biasAdd6 = this.buildConv_(
         conv17Relu6, ['BoxEncoding', '1'], false);
-    const biasAdd9 = await this.buildConv_(
+    const biasAdd9 = this.buildConv_(
         conv17Relu6, ['Class', '1'], false);
 
-    const conv18Relu6 = await this.buildConv_(
+    const conv18Relu6 = this.buildConv_(
         conv17Relu6, ['layer_19_1', '2_1x1_256']);
-    const conv19Relu6 = await this.buildConv_(
+    const conv19Relu6 = this.buildConv_(
         conv18Relu6, ['layer_19_2', '2_3x3_s2_512'], true, {strides: [2, 2]});
-    const biasAdd12 = await this.buildConv_(
+    const biasAdd12 = this.buildConv_(
         conv19Relu6, ['BoxEncoding', '2'], false);
-    const biasAdd15 = await this.buildConv_(
+    const biasAdd15 = this.buildConv_(
         conv19Relu6, ['Class', '2'], false);
 
-    const conv20Relu6 = await this.buildConv_(
+    const conv20Relu6 = this.buildConv_(
         conv19Relu6, ['layer_19_1', '3_1x1_128']);
-    const conv21Relu6 = await this.buildConv_(
+    const conv21Relu6 = this.buildConv_(
         conv20Relu6, ['layer_19_2', '3_3x3_s2_256'], true, {strides: [2, 2]});
-    const biasAdd18 = await this.buildConv_(
+    const biasAdd18 = this.buildConv_(
         conv21Relu6, ['BoxEncoding', '3'], false);
-    const biasAdd21 = await this.buildConv_(
+    const biasAdd21 = this.buildConv_(
         conv21Relu6, ['Class', '3'], false);
 
-    const conv22Relu6 = await this.buildConv_(
+    const conv22Relu6 = this.buildConv_(
         conv21Relu6, ['layer_19_1', '4_1x1_128']);
-    const conv23Relu6 = await this.buildConv_(
+    const conv23Relu6 = this.buildConv_(
         conv22Relu6, ['layer_19_2', '4_3x3_s2_256'], true, {strides: [2, 2]});
-    const biasAdd24 = await this.buildConv_(
+    const biasAdd24 = this.buildConv_(
         conv23Relu6, ['BoxEncoding', '4'], false);
-    const biasAdd27 = await this.buildConv_(
+    const biasAdd27 = this.buildConv_(
         conv23Relu6, ['Class', '4'], false);
 
-    const conv24Relu6 = await this.buildConv_(
+    const conv24Relu6 = this.buildConv_(
         conv23Relu6, ['layer_19_1', '5_1x1_64']);
-    const conv25Relu6 = await this.buildConv_(
+    const conv25Relu6 = this.buildConv_(
         conv24Relu6, ['layer_19_2', '5_3x3_s2_128'], true, {strides: [2, 2]});
-    const biasAdd30 = await this.buildConv_(
+    const biasAdd30 = this.buildConv_(
         conv25Relu6, ['BoxEncoding', '5'], false);
-    const biasAdd33 = await this.buildConv_(
+    const biasAdd33 = this.buildConv_(
         conv25Relu6, ['Class', '5'], false);
 
-    return {biasAdd0, biasAdd3, biasAdd6, biasAdd9, biasAdd12, biasAdd15,
-      biasAdd18, biasAdd21, biasAdd24, biasAdd27, biasAdd30, biasAdd33};
+    return {
+      biasAdd0: await biasAdd0,
+      biasAdd3: await biasAdd3,
+      biasAdd6: await biasAdd6,
+      biasAdd9: await biasAdd9,
+      biasAdd12: await biasAdd12,
+      biasAdd15: await biasAdd15,
+      biasAdd18: await biasAdd18,
+      biasAdd21: await biasAdd21,
+      biasAdd24: await biasAdd24,
+      biasAdd27: await biasAdd27,
+      biasAdd30: await biasAdd30,
+      biasAdd33: await biasAdd33
+    };
   }
 
   async build(outputOperand) {


### PR DESCRIPTION
This model separates each constant value into a separate NumPy file which needs to be fetched. This change refactors the graph construction so that these fetches can happen in parallel rather than waiting for each fetch to complete before building that graph layer.

This is an experiment to determine whether it would be more ergonomic for the graph builder functions to accept promises so that this kind of code can be written without the careful placement of awaits demonstrated here.