### PR TITLE
Disable WebNN CPU for LeNet

### DIFF
--- a/lenet/index.html
+++ b/lenet/index.html
@@ -34,9 +34,9 @@
                 <label class="btn btn-outline-info" name="polyfill">
                   <input type="radio" name="backend" id="polyfill_gpu" autocomplete="off">WebGL (GPU)
                 </label>
-                <label class="btn disabled btn-outline-secondary" name="webnn">
+                <!-- <label class="btn btn-outline-info" name="webnn">
                   <input type="radio" name="backend" id="webnn_cpu" autocomplete="off" disabled>WebNN (CPU)
-                </label>
+                </label> -->
                 <label class="btn btn-outline-info" name="webnn">
                   <input type="radio" name="backend" id="webnn_gpu" autocomplete="off">WebNN (GPU)
                 </label>

--- a/lenet/index.html
+++ b/lenet/index.html
@@ -34,8 +34,8 @@
                 <label class="btn btn-outline-info" name="polyfill">
                   <input type="radio" name="backend" id="polyfill_gpu" autocomplete="off">WebGL (GPU)
                 </label>
-                <label class="btn btn-outline-info" name="webnn">
-                  <input type="radio" name="backend" id="webnn_cpu" autocomplete="off">WebNN (CPU)
+                <label class="btn disabled btn-outline-secondary" name="webnn">
+                  <input type="radio" name="backend" id="webnn_cpu" autocomplete="off" disabled>WebNN (CPU)
                 </label>
                 <label class="btn btn-outline-info" name="webnn">
                   <input type="radio" name="backend" id="webnn_gpu" autocomplete="off">WebNN (GPU)


### PR DESCRIPTION
> Handwritten Digits Classification: The input layout nchw is not supported when select WebNN (CPU).

There is no lenet_nchw weights files under https://github.com/webmachinelearning/test-data/tree/main/models . Disable "WebNN CPU" in WebNN Samples.

@huningxin @Honry PTAL