### PR TITLE
Support CPU backend for LeNet sample

### DIFF
--- a/lenet/index.html
+++ b/lenet/index.html
@@ -34,9 +34,9 @@
                 <label class="btn btn-outline-info" name="polyfill">
                   <input type="radio" name="backend" id="polyfill_gpu" autocomplete="off">WebGL (GPU)
                 </label>
-                <!-- <label class="btn btn-outline-info" name="webnn">
-                  <input type="radio" name="backend" id="webnn_cpu" autocomplete="off" disabled>WebNN (CPU)
-                </label> -->
+                <label class="btn btn-outline-info" name="webnn">
+                  <input type="radio" name="backend" id="webnn_cpu" autocomplete="off">WebNN (CPU)
+                </label>
                 <label class="btn btn-outline-info" name="webnn">
                   <input type="radio" name="backend" id="webnn_gpu" autocomplete="off">WebNN (GPU)
                 </label>

--- a/lenet/lenet.js
+++ b/lenet/lenet.js
@@ -1,14 +1,18 @@
 
 'use strict';
 
-import {getBufferFromUrl, sizeOfShape} from '../common/utils.js';
+import {getBufferFromUrl, sizeOfShape, permuteData} from '../common/utils.js';
 
 export class LeNet {
-  constructor(url) {
+  constructor(url, layout) {
     this.context_ = null;
     this.url_ = url;
     this.graph_ = null;
     this.builder_ = null;
+    this.layout_ = layout;
+    this.nchwToNhwcPermutation_ = [0, 2, 3, 1];
+    this.nhwcToNchwPermutation_ = [0, 3, 1, 2];
+    this.oihwToOhwiPermutation_ = [0, 2, 3, 1];
   }
 
   async load(contextOptions) {
@@ -20,25 +24,38 @@ export class LeNet {
 
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
-    const inputShape = [1, 1, 28, 28];
-    const input = this.builder_.input('input', {
-      type: 'float32',
+    const inputShape = /* nchw */ [1, 1, 28, 28];
+    let input = this.builder_.input('input', {
       dataType: 'float32',
       dimensions: inputShape,
     });
 
-    const conv1FitlerShape = [20, 1, 5, 5];
+    if (this.layout_ === 'nhwc') {
+      input = this.builder_.transpose(
+          input, {permutation: this.nchwToNhwcPermutation_});
+    }
+
+    const conv1Options = {};
+    if (this.layout_ === 'nhwc') {
+      conv1Options.inputLayout = 'nhwc';
+      conv1Options.filterLayout = 'ohwi';
+    }
+    let conv1FitlerShape = /* oihw */ [20, 1, 5, 5];
     let byteOffset = 0;
-    const conv1FilterData = new Float32Array(
+    let conv1FilterData = new Float32Array(
         arrayBuffer, byteOffset, sizeOfShape(conv1FitlerShape));
+    if (this.layout_ === 'nhwc') {
+      [conv1FilterData, conv1FitlerShape] =
+          permuteData(
+              conv1FilterData, conv1FitlerShape, this.oihwToOhwiPermutation_);
+    }
     const conv1Filter = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: conv1FitlerShape},
+        {dataType: 'float32', dimensions: conv1FitlerShape},
         conv1FilterData);
     byteOffset +=
         sizeOfShape(conv1FitlerShape) * Float32Array.BYTES_PER_ELEMENT;
-    const conv1 = this.builder_.conv2d(input, conv1Filter);
 
-    const add1BiasShape = [1, 20, 1, 1];
+    const add1BiasShape = [20];
     const add1BiasData =
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add1BiasShape));
     const add1Bias = this.builder_.constant(
@@ -46,36 +63,54 @@ export class LeNet {
         add1BiasData,
     );
     byteOffset += sizeOfShape(add1BiasShape) * Float32Array.BYTES_PER_ELEMENT;
-    const add1 = this.builder_.add(conv1, add1Bias);
+    conv1Options.bias = add1Bias;
+
+    const conv1 = this.builder_.conv2d(input, conv1Filter, conv1Options);
 
     const pool1WindowShape = [2, 2];
     const pool1Strides = [2, 2];
     const pool1 =
-        this.builder_.maxPool2d(add1, {windowDimensions: pool1WindowShape,
-          strides: pool1Strides});
+        this.builder_.maxPool2d(conv1, {windowDimensions: pool1WindowShape,
+          strides: pool1Strides, layout: this.layout_});
 
-    const conv2FilterShape = [50, 20, 5, 5];
+    const conv2Options = {};
+    if (this.layout_ === 'nhwc') {
+      conv2Options.inputLayout = 'nhwc';
+      conv2Options.filterLayout = 'ohwi';
+    }
+    let conv2FilterShape = /* oihw */ [50, 20, 5, 5];
+    let conv2FilterData = new Float32Array(
+        arrayBuffer, byteOffset, sizeOfShape(conv2FilterShape));
+    if (this.layout_ === 'nhwc') {
+      [conv2FilterData, conv2FilterShape] =
+          permuteData(
+              conv2FilterData, conv2FilterShape, this.oihwToOhwiPermutation_);
+    }
     const conv2Filter = this.builder_.constant(
         {type: 'float32', dataType: 'float32', dimensions: conv2FilterShape},
-        new Float32Array(
-            arrayBuffer, byteOffset, sizeOfShape(conv2FilterShape)),
-    );
+        conv2FilterData);
     byteOffset +=
         sizeOfShape(conv2FilterShape) * Float32Array.BYTES_PER_ELEMENT;
-    const conv2 = this.builder_.conv2d(pool1, conv2Filter);
 
-    const add2BiasShape = [1, 50, 1, 1];
+    const add2BiasShape = [50];
     const add2Bias = this.builder_.constant(
         {type: 'float32', dataType: 'float32', dimensions: add2BiasShape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add2BiasShape)));
     byteOffset += sizeOfShape(add2BiasShape) * Float32Array.BYTES_PER_ELEMENT;
-    const add2 = this.builder_.add(conv2, add2Bias);
+    conv2Options.bias = add2Bias;
+
+    const conv2 = this.builder_.conv2d(pool1, conv2Filter, conv2Options);
 
     const pool2WindowShape = [2, 2];
     const pool2Strides = [2, 2];
-    const pool2 =
-        this.builder_.maxPool2d(add2, {windowDimensions: pool2WindowShape,
-          strides: pool2Strides});
+    let pool2 =
+        this.builder_.maxPool2d(conv2, {windowDimensions: pool2WindowShape,
+          strides: pool2Strides, layout: this.layout_});
+
+    if (this.layout_ === 'nhwc') {
+      pool2 = this.builder_.transpose(
+          pool2, {permutation: this.nhwcToNchwPermutation_});
+    }
 
     const reshape1Shape = [1, 800];
     const reshape1 = this.builder_.reshape(pool2, reshape1Shape);
@@ -89,7 +124,7 @@ export class LeNet {
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(matmul1Shape)));
     byteOffset += sizeOfShape(matmul1Shape) * Float32Array.BYTES_PER_ELEMENT;
     const matmul1WeightsTransposed = this.builder_.transpose(matmul1Weights);
-    const matmul1 = this.builder_.matmul(reshape1, matmul1WeightsTransposed);
+    const matmul1 = this.builder_.gemm(reshape1, matmul1WeightsTransposed);
 
     const add3BiasShape = [1, 500];
     const add3Bias = this.builder_.constant(
@@ -109,7 +144,7 @@ export class LeNet {
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(matmul2Shape)));
     byteOffset += sizeOfShape(matmul2Shape) * Float32Array.BYTES_PER_ELEMENT;
     const matmul2WeightsTransposed = this.builder_.transpose(matmul2Weights);
-    const matmul2 = this.builder_.matmul(reshape2, matmul2WeightsTransposed);
+    const matmul2 = this.builder_.gemm(reshape2, matmul2WeightsTransposed);
 
     const add4BiasShape = [1, 10];
     const add4Bias = this.builder_.constant(


### PR DESCRIPTION
The changes of this PR include:
1. Revert #204.
1. Support nhwc conv2d and pool2d for LeNet and use nhwc for CPU device.
1. Derive permuteData function from transformers.js that is used to permute the filter data.
1. Use gemm to replace matmul, because XNNPACK matmul doesn't support 2D inputs.
1. Fix some issues of UI.

/cc @ibelem 