### PR TITLE
Add padding for convTranspose2d ops of fast style transfer example

### DIFF
--- a/style_transfer/fast_style_transfer_net.js
+++ b/style_transfer/fast_style_transfer_net.js
@@ -172,12 +172,12 @@ export class FastStyleTransferNet {
     const add16 = this.buildInstanceNormalization_(conv2D12, variableMul12, variableAdd12);
     const add17 = this.builder_.add(add14, add16);
     const convTranspose0 = this.builder_.convTranspose2d(add17, weightConvTranspose0,
-        {strides: [2, 2], outputSizes: [270, 270]});
+        {padding: [0, 1, 0, 1], strides: [2, 2], outputSizes: [270, 270]});
 
     const add18 = this.buildInstanceNormalization_(convTranspose0, variableMul13, variableAdd13);
     const relu8 = this.builder_.relu(add18);
     const convTranspose1 = this.builder_.convTranspose2d(relu8, weightConvTranspose1,
-        {strides: [2, 2], outputSizes: [540, 540]});
+        {padding: [0, 1, 0, 1], strides: [2, 2], outputSizes: [540, 540]});
 
     const add19 = this.buildInstanceNormalization_(convTranspose1, variableMul14, variableAdd14);
     const relu9 = this.builder_.relu(add19);


### PR DESCRIPTION
According to ONNX ConvTranspose op spec [1], the shape of the output can be explicitly set which will cause pads values to be auto generated. The previous code misses the padding that will cause WebNN output size validation error.

[1]: https://onnx.ai/onnx/operators/onnx__ConvTranspose.html

/cc @miaobin 