### PR TITLE
Disable the WebNN CPU backend of NSNet2 and RNNoise

### DIFF
--- a/nsnet2/index.html
+++ b/nsnet2/index.html
@@ -34,9 +34,9 @@
                 <label class="btn btn-outline-info" name="polyfill">
                   <input type="radio" name="backend" id="polyfill_gpu" autocomplete="off">WebGL (GPU)
                 </label>
-                <label class="btn btn-outline-info" name="webnn">
+                <!-- <label class="btn btn-outline-info" name="webnn">
                   <input type="radio" name="backend" id="webnn_cpu" autocomplete="off">WebNN (CPU)
-                </label>
+                </label> -->
                 <label class="btn btn-outline-info" name="webnn">
                   <input type="radio" name="backend" id="webnn_gpu" autocomplete="off">WebNN (GPU)
                 </label>

--- a/rnnoise/index.html
+++ b/rnnoise/index.html
@@ -34,9 +34,9 @@
                 <label class="btn btn-outline-info" name="polyfill">
                   <input type="radio" name="backend" id="polyfill_gpu" autocomplete="off">WebGL (GPU)
                 </label>
-                <label class="btn btn-outline-info" name="webnn">
+                <!-- <label class="btn btn-outline-info" name="webnn">
                   <input type="radio" name="backend" id="webnn_cpu" autocomplete="off">WebNN (CPU)
-                </label>
+                </label> -->
                 <label class="btn btn-outline-info" name="webnn">
                   <input type="radio" name="backend" id="webnn_gpu" autocomplete="off">WebNN (GPU)
                 </label>


### PR DESCRIPTION
There are some limitations on WebNN CPU backens for NSNet2 and RNNoise models, disable the backend temporarily.
 
@huningxin @Honry PTAL