### PR TITLE
Fix ArrayBuffer detach issue for noise suppression samples

### DIFF
--- a/nsnet2/nsnet2.js
+++ b/nsnet2/nsnet2.js
@@ -83,9 +83,9 @@ export class NSNet2 {
       'initialState155': initialState155Buffer,
     };
     const outputs = {
-      'output': outputBuffer,
-      'gru94': gru94Buffer,
-      'gru157': gru157Buffer,
+      'output': outputBuffer.slice(),
+      'gru94': gru94Buffer.slice(),
+      'gru157': gru157Buffer.slice(),
     };
     const results = await this.context_.compute(this.graph_, inputs, outputs);
     return results.outputs;

--- a/rnnoise/main.js
+++ b/rnnoise/main.js
@@ -146,9 +146,9 @@ async function denoise() {
     start = performance.now();
     outputs = await rnnoise.compute(inputs, outputs);
     const executionTime = (performance.now() - start).toFixed(2);
-    inputs.vadGruInitialH = outputs.vadGruYH;
-    inputs.noiseGruInitialH = outputs.noiseGruYH;
-    inputs.denoiseGruInitialH = outputs.denoiseGruYH;
+    inputs.vadGruInitialH = outputs.vadGruYH.slice();
+    inputs.noiseGruInitialH = outputs.noiseGruYH.slice();
+    inputs.denoiseGruInitialH = outputs.denoiseGruYH.slice();
 
     start = performance.now();
     const output = analyser.postProcessing(outputs.denoiseOutput);


### PR DESCRIPTION
Copy the outputs ArrayBuffer to the inputs to avoid the input and output are the same ArrayBufferView in WebNN GPU backend.
For NSNet2 sample we still need the [fix](https://chromium-review.googlesource.com/c/chromium/src/+/5409911) to run correctly.
@huningxin @Honry PTAL, thanks.