### PR TITLE
Fixed CI: upgrade the node version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: '12.x'
+        node-version: '18.x'
 
     - run: npm install
 


### PR DESCRIPTION
Currently CI always fails on macos-latest because node 12+ could not been found on MacOS, upgrade the node to fix it.