### PR TITLE
Fix UI issue for image classification

### DIFF
--- a/image_classification/main.js
+++ b/image_classification/main.js
@@ -125,10 +125,12 @@ $('#backendBtns .btn').on('change', async (e) => {
   } else if (deviceType == 'npu') {
     ui.handleBtnUI('#float16Label', false);
     ui.handleBtnUI('#float32Label', true);
+    $('#float16').click();
     displayAvailableModels(modelList, deviceType, 'float16');
   } else {
     ui.handleBtnUI('#float16Label', true);
     ui.handleBtnUI('#float32Label', false);
+    $('#float32').click();
     displayAvailableModels(modelList, deviceType, 'float32');
   }
 


### PR DESCRIPTION
When switch to NPU and choose model directly, it will throw error as the data type doesn't change correspondingly, fix it by clicking the correct data type if switch to NPU or CPU.