### PR TITLE
Remove deprecated MLOperandDescriptor.type

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -121,7 +121,7 @@ export async function buildConstantByNpy(builder, url, targetType = 'float32') {
     throw new Error(`Conversion from ${npArray.dataType} ` +
         `to ${targetType} is not supported.`);
   }
-  return builder.constant({dataType: type, type, dimensions}, typedArray);
+  return builder.constant({dataType: type, dimensions}, typedArray);
 }
 
 // Convert video frame to a canvas element

--- a/face_recognition/facenet_nchw.js
+++ b/face_recognition/facenet_nchw.js
@@ -134,7 +134,6 @@ export class FaceNetNchw {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/face_recognition/facenet_nhwc.js
+++ b/face_recognition/facenet_nhwc.js
@@ -135,7 +135,6 @@ export class FaceNetNhwc {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/facial_landmark_detection/face_landmark_nchw.js
+++ b/facial_landmark_detection/face_landmark_nchw.js
@@ -70,7 +70,6 @@ export class FaceLandmarkNchw {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/facial_landmark_detection/face_landmark_nhwc.js
+++ b/facial_landmark_detection/face_landmark_nhwc.js
@@ -71,7 +71,6 @@ export class FaceLandmarkNhwc {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/facial_landmark_detection/ssd_mobilenetv2_face_nchw.js
+++ b/facial_landmark_detection/ssd_mobilenetv2_face_nchw.js
@@ -122,7 +122,6 @@ ${nameArray[1]}`;
     this.deviceType_ = contextOptions.deviceType;
     this.builder_ = new MLGraphBuilder(this.context_);
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/facial_landmark_detection/ssd_mobilenetv2_face_nhwc.js
+++ b/facial_landmark_detection/ssd_mobilenetv2_face_nhwc.js
@@ -134,7 +134,6 @@ ${nameArray[1]}`;
     this.deviceType_ = contextOptions.deviceType;
     this.builder_ = new MLGraphBuilder(this.context_);
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/image_classification/mobilenet_nhwc.js
+++ b/image_classification/mobilenet_nhwc.js
@@ -96,7 +96,6 @@ export class MobileNetV2Nhwc {
     const autoPad = 'same-upper';
     const filterLayout = 'ohwi';
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/image_classification/resnet50v2_nchw.js
+++ b/image_classification/resnet50v2_nchw.js
@@ -101,7 +101,6 @@ export class ResNet50V2Nchw {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
     const data = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/image_classification/resnet50v2_nhwc.js
+++ b/image_classification/resnet50v2_nhwc.js
@@ -123,7 +123,6 @@ export class ResNet50V2Nhwc {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/image_classification/squeezenet_nchw.js
+++ b/image_classification/squeezenet_nchw.js
@@ -44,7 +44,6 @@ export class SqueezeNetNchw {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
     const data = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/image_classification/squeezenet_nhwc.js
+++ b/image_classification/squeezenet_nhwc.js
@@ -55,7 +55,6 @@ export class SqueezeNetNhwc {
     const strides = [2, 2];
     const layout = 'nhwc';
     const placeholder = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/lenet/lenet.js
+++ b/lenet/lenet.js
@@ -59,7 +59,7 @@ export class LeNet {
     const add1BiasData =
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add1BiasShape));
     const add1Bias = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: add1BiasShape},
+        {dataType: 'float32', dimensions: add1BiasShape},
         add1BiasData,
     );
     byteOffset += sizeOfShape(add1BiasShape) * Float32Array.BYTES_PER_ELEMENT;
@@ -87,14 +87,14 @@ export class LeNet {
               conv2FilterData, conv2FilterShape, this.oihwToOhwiPermutation_);
     }
     const conv2Filter = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: conv2FilterShape},
+        {dataType: 'float32', dimensions: conv2FilterShape},
         conv2FilterData);
     byteOffset +=
         sizeOfShape(conv2FilterShape) * Float32Array.BYTES_PER_ELEMENT;
 
     const add2BiasShape = [50];
     const add2Bias = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: add2BiasShape},
+        {dataType: 'float32', dimensions: add2BiasShape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add2BiasShape)));
     byteOffset += sizeOfShape(add2BiasShape) * Float32Array.BYTES_PER_ELEMENT;
     conv2Options.bias = add2Bias;
@@ -120,7 +120,7 @@ export class LeNet {
 
     const matmul1Shape = [500, 800];
     const matmul1Weights = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: matmul1Shape},
+        {dataType: 'float32', dimensions: matmul1Shape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(matmul1Shape)));
     byteOffset += sizeOfShape(matmul1Shape) * Float32Array.BYTES_PER_ELEMENT;
     const matmul1WeightsTransposed = this.builder_.transpose(matmul1Weights);
@@ -128,7 +128,7 @@ export class LeNet {
 
     const add3BiasShape = [1, 500];
     const add3Bias = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: add3BiasShape},
+        {dataType: 'float32', dimensions: add3BiasShape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add3BiasShape)));
     byteOffset += sizeOfShape(add3BiasShape) * Float32Array.BYTES_PER_ELEMENT;
     const add3 = this.builder_.add(matmul1, add3Bias);
@@ -140,7 +140,7 @@ export class LeNet {
 
     const matmul2Shape = [10, 500];
     const matmul2Weights = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: matmul2Shape},
+        {dataType: 'float32', dimensions: matmul2Shape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(matmul2Shape)));
     byteOffset += sizeOfShape(matmul2Shape) * Float32Array.BYTES_PER_ELEMENT;
     const matmul2WeightsTransposed = this.builder_.transpose(matmul2Weights);
@@ -148,7 +148,7 @@ export class LeNet {
 
     const add4BiasShape = [1, 10];
     const add4Bias = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: add4BiasShape},
+        {dataType: 'float32', dimensions: add4BiasShape},
         new Float32Array(arrayBuffer, byteOffset, sizeOfShape(add4BiasShape)));
     const add4 = this.builder_.add(matmul2, add4Bias);
 

--- a/nsnet2/nsnet2.js
+++ b/nsnet2/nsnet2.js
@@ -37,14 +37,12 @@ export class NSNet2 {
     const biasFcOut4 = await buildConstantByNpy(this.builder_, baseUrl + 'fc_out_4_bias.npy');
     // Build up the network.
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: [batchSize, frames, this.frameSize],
     });
     const relu20 = this.builder_.relu(this.builder_.add(this.builder_.matmul(input, weight172), biasFcIn0));
     const transpose31 = this.builder_.transpose(relu20, {permutation: [1, 0, 2]});
     const initialState92 = this.builder_.input('initialState92', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: [1, batchSize, this.hiddenSize],
     });
@@ -55,7 +53,6 @@ export class NSNet2 {
     squeeze95Shape.splice(1, 1);
     const squeeze95 = this.builder_.reshape(gru93, squeeze95Shape);
     const initialState155 = this.builder_.input('initialState155', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: [1, batchSize, this.hiddenSize],
     });

--- a/object_detection/ssd_mobilenetv1_nhwc.js
+++ b/object_detection/ssd_mobilenetv1_nhwc.js
@@ -94,7 +94,6 @@ ${nameArray[1]}_BatchNorm_batchnorm`;
     this.deviceType_ = contextOptions.deviceType;
     this.builder_ = new MLGraphBuilder(this.context_);
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/object_detection/tiny_yolov2_nhwc.js
+++ b/object_detection/tiny_yolov2_nhwc.js
@@ -56,7 +56,6 @@ export class TinyYoloV2Nhwc {
     this.context_ = await navigator.ml.createContext(contextOptions);
     this.builder_ = new MLGraphBuilder(this.context_);
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/rnnoise/rnnoise.js
+++ b/rnnoise/rnnoise.js
@@ -52,7 +52,6 @@ export class RNNoise {
         this.baseUrl_ + 'denoise_output_bias_0.npy');
     // Build up the network.
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: [this.batchSize_, this.frames_, this.featureSize],
     });
@@ -68,7 +67,6 @@ export class RNNoise {
         [0, 3 * this.vadGruHiddenSize],
         [1, 3 * this.vadGruHiddenSize]);
     const vadGruInitialH = this.builder_.input('vadGruInitialH', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: [1, this.batchSize_, this.vadGruHiddenSize],
     });
@@ -96,7 +94,6 @@ export class RNNoise {
         [0, 3 * this.noiseGruHiddenSize],
         [1, 3 * this.noiseGruHiddenSize]);
     const noiseGruInitialH = this.builder_.input('noiseGruInitialH', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: [1, this.batchSize_, this.noiseGruHiddenSize],
     });
@@ -124,7 +121,6 @@ export class RNNoise {
         [0, 3 * this.denoiseGruHiddenSize],
         [1, 3 * this.denoiseGruHiddenSize]);
     const denoiseGruInitialH = this.builder_.input('denoiseGruInitialH', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: [1, this.batchSize_, this.denoiseGruHiddenSize],
     });

--- a/semantic_segmentation/deeplabv3_mnv2_nchw.js
+++ b/semantic_segmentation/deeplabv3_mnv2_nchw.js
@@ -98,7 +98,6 @@ export class DeepLabV3MNV2Nchw {
     const strides = [2, 2];
 
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/semantic_segmentation/deeplabv3_mnv2_nhwc.js
+++ b/semantic_segmentation/deeplabv3_mnv2_nhwc.js
@@ -88,7 +88,6 @@ export class DeepLabV3MNV2Nhwc {
     this.builder_ = new MLGraphBuilder(this.context_);
     const strides = [2, 2];
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });

--- a/style_transfer/fast_style_transfer_net.js
+++ b/style_transfer/fast_style_transfer_net.js
@@ -96,24 +96,23 @@ export class FastStyleTransferNet {
     const padding1 = [0, 0, 1, 1];
     const padding4 = [0, 0, 4, 4];
     this.constAdd_ = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: [1]},
+        {dataType: 'float32', dimensions: [1]},
         new Float32Array([9.999999717180685e-10]),
     );
     this.constPow_ = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: [1]},
+        {dataType: 'float32', dimensions: [1]},
         new Float32Array([0.5]),
     );
     const constMul0 = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: [1]},
+        {dataType: 'float32', dimensions: [1]},
         new Float32Array([150]),
     );
     const constAdd0 = this.builder_.constant(
-        {type: 'float32', dataType: 'float32', dimensions: [1]},
+        {dataType: 'float32', dimensions: [1]},
         new Float32Array([127.5]),
     );
     // Build up the network.
     const input = this.builder_.input('input', {
-      type: 'float32',
       dataType: 'float32',
       dimensions: this.inputOptions.inputDimensions,
     });


### PR DESCRIPTION
Now latest Chrome has supported MLOperandDescriptor.dataType, we can remove deprecated MLOperandDescriptor.type.