### PR TITLE
Add basic-ssl plugin in vite to remove openssl new key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ To get started, follow these steps:
  ```bash
 > git clone --recurse-submodules https://github.com/webmachinelearning/webnn-samples
 > cd webnn-samples
-> openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem
 > npm install
-> npm start
+> npm run start
 ```
 2. Navigate to the desired sample directory that you want to explore.
 3. Read the accompanying README.md file for the sample to understand its purpose, requirements, and implementation details.

--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
     "@babel/plugin-syntax-top-level-await": "^7.12.1",
     "eslint": "^7.5.0",
     "eslint-config-google": "^0.14.0",
-    "http-server": "^0.12.3"
+    "@vitejs/plugin-basic-ssl": "^1.1.0",
+    "vite": "^5.1.7"
   },
   "scripts": {
     "lint": "eslint . --ext .js",
-    "start": "http-server -S cert.pem -o"
+    "start": "vite --host"
   },
   "dependencies": {
     "babel-eslint": "^8.0.3"

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vite';
+import basicSsl from '@vitejs/plugin-basic-ssl';
+
+export default defineConfig({
+  build: {
+    target: 'esnext',
+  },
+  plugins: [basicSsl()],
+});


### PR DESCRIPTION
The step `openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem` is annoying, remove it by using basic-ssl plugin in vite.

@Honry @huningxin PTAL