### PR TITLE
NNotepad: fix load(), add zeros(), improve tensor output display

### DIFF
--- a/nnotepad/README.md
+++ b/nnotepad/README.md
@@ -49,6 +49,7 @@ The default [data type](https://webmachinelearning.github.io/webnn/#enumdef-mlop
 In addition to WebNN [`MLGraphBuilder`](https://webmachinelearning.github.io/webnn/#mlgraphbuilder) methods, you can use these helpers:
 
 * **load(_url_, _shape_, _dataType_)** - fetch a tensor resource. Must be served with appropriate [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) headers. Example: `load('https://www.random.org/cgi-bin/randbyte?nbytes=256', [16, 16], 'uint8')`
+* **zeros(_shape_, _dataType_)** - constant zero-filled tensor of the given shape. Example: `zeros([2,2,2,2], 'int8')`
 
 
 # Details & Gotchas

--- a/nnotepad/js/index.js
+++ b/nnotepad/js/index.js
@@ -79,7 +79,7 @@ function explain(outputs) {
 
     const width = [...buffer]
         .map((n) => String(n).length)
-        .reduce((a, b) => Math.max(a, b));
+        .reduce((a, b) => Math.max(a, b), 0);
 
     const out = [];
     let bufferIndex = 0;
@@ -95,10 +95,7 @@ function explain(outputs) {
         if (i !== shape[dim] - 1) {
           out.push(', ');
           if (dim + 1 !== shape.length) {
-            if (dim + 2 !== shape.length) {
-              out.push('\n');
-            }
-            out.push('\n');
+            out.push('\n'.repeat(shape.length - dim - 1));
             out.push(' '.repeat(indent + dim + 1));
           }
         }

--- a/nnotepad/res/docs.html
+++ b/nnotepad/res/docs.html
@@ -77,6 +77,7 @@ matmul(A,B)
 <p>In addition to WebNN <a href="https://webmachinelearning.github.io/webnn/#mlgraphbuilder"><code>MLGraphBuilder</code></a> methods, you can use these helpers:</p>
 <ul>
 <li><strong>load(<em>url</em>, <em>shape</em>, <em>dataType</em>)</strong> - fetch a tensor resource. Must be served with appropriate <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS">CORS</a> headers. Example: <code>load('https://www.random.org/cgi-bin/randbyte?nbytes=256', [16, 16], 'uint8')</code></li>
+<li><strong>zeros(<em>shape</em>, <em>dataType</em>)</strong> - constant zero-filled tensor of the given shape. Example: <code>zeros([2,2,2,2], 'int8')</code></li>
 </ul>
 <h1>Details &amp; Gotchas</h1>
 <ul>


### PR DESCRIPTION
- The load() helper was broken when the scripts were converted to modules, and also when array parsing was updated. Oops! Fix it.
- Add zeros() helper that creates a zero-initized tensor of the given shape. Useful for testing shape display.
- Ensure tensor output spaces n-dimensions tensors the same as numpy - more spaces between each layer.
- Ensure tensor output handles 0-sized dimensions.