### PR TITLE
[NNotepad] Fix #253 e.target.close is not a function error

### DIFF
--- a/nnotepad/js/index.js
+++ b/nnotepad/js/index.js
@@ -71,6 +71,10 @@ document.addEventListener('DOMContentLoaded', async (e) => {
   );
   $$('dialog').forEach((dialog) => {
     dialog.addEventListener('click', (e) => {
+      if (e.target &&
+        (e.target.id === 'srcClose' || e.target.id === 'helpClose')) {
+        return;
+      }
       const rect = e.target.getBoundingClientRect();
       if (
         e.clientY < rect.top ||

--- a/nnotepad/js/index.js
+++ b/nnotepad/js/index.js
@@ -71,10 +71,7 @@ document.addEventListener('DOMContentLoaded', async (e) => {
   );
   $$('dialog').forEach((dialog) => {
     dialog.addEventListener('click', (e) => {
-      if (e.target &&
-        (e.target.id === 'srcClose' || e.target.id === 'helpClose')) {
-        return;
-      }
+      if (e.target !== dialog) return;
       const rect = e.target.getBoundingClientRect();
       if (
         e.clientY < rect.top ||


### PR DESCRIPTION
Fix #253

Click "Close" button in "Show generated code" or "Show documentation" dialog not only triggers button click event but also the dialog click event, which makes the e.target in dialog click event quals the dialog element and button element, but there is no close() method for buttons.

@inexorabletash @anssiko @Honry PTAL