### PR TITLE
[NNotepad] Debounced refresh()

### DIFF
--- a/nnotepad/js/index.js
+++ b/nnotepad/js/index.js
@@ -24,9 +24,8 @@ document.addEventListener('DOMContentLoaded', async (e) => {
     disableMonospaceOptimizations: true,
   });
 
-  editor.onDidChangeModelContent(() => {
-    refresh();
-  });
+  const debouncedRefresh = Util.debounce(refresh, 500);
+  editor.onDidChangeModelContent(debouncedRefresh);
 
   async function refresh(e) {
     const code = editor.getValue();


### PR DESCRIPTION
@inexorabletash asked to double check if the content model change callbacks are throttled when deleting `$('#input').addEventListener('input', Util.debounce(refresh, 500));` in https://github.com/webmachinelearning/webnn-samples/pull/257. 

> The shape of the `IModelContentChangedEvent` emitted via `IModel.onDidChangeContent`. 
> https://github.com/microsoft/monaco-editor/blob/main/src/language/typescript/languageFeatures.ts#L209
> https://github.com/microsoft/monaco-editor/blob/main/src/language/common/lspLanguageFeatures.ts#L47

Since there are some code usages above for validate method with 500ms in monaco-editor source code, add debounced refresh() back.

@inexorabletash @anssiko @Honry PTAL