### PR TITLE
NNotepad: Add custom syntax highlighting, editor configuration

### DIFF
--- a/nnotepad/js/index.js
+++ b/nnotepad/js/index.js
@@ -15,9 +15,10 @@ document.addEventListener('DOMContentLoaded', async (e) => {
     console.warn(ex);
   }
 
+  NNotepad.addMonacoLanguage(monaco);
   const editor = monaco.editor.create($('#input'), {
     value: inputValue,
-    language: 'markdown',
+    language: NNotepad.monacoLanguageId,
     lineNumbers: 'on',
     automaticLayout: true,
     theme: 'vs',


### PR DESCRIPTION
This introduces a basic declarative syntax highlighter via Monarch (https://microsoft.github.io/monaco-editor/monarch.html). The parsing isn't perfect, and there could be some deduplication in nnotepad.js but this is an improvement over using the markdown highlighter.

It also provides a language configuration to control bracket pairing and auto-closing, and auto-complete of MLGraphBuilder methods.

Fixes #256