### PR TITLE
[NNotepad] Parser edge case fixes

### DIFF
--- a/nnotepad/js/nnotepad.js
+++ b/nnotepad/js/nnotepad.js
@@ -136,11 +136,12 @@ export class NNotepad {
     // Tokens
     const kCommentPattern = '(#|//).*';
     const kNumberPattern =
-        'NaN|Infinity|-Infinity|-?\\d+(\\.\\d+)?([eE]-?\\d+)?';
+        'NaN\\b|Infinity\\b|-Infinity\\b|-?\\d+(\\.\\d+)?([eE]-?\\d+)?';
     const kStringPattern =
         `"([^\\\\\\x0A\\x0D"]|\\\\.)*"|'([^\\\\\\x0A\\x0D']|\\\\.)*'`;
-    const kBooleanPattern = 'true|false';
-    const kSuffixPattern = `u8|u32|u64|i8|i32|i64|f16|f32`;
+    const kBooleanPattern = 'true\\b|false\\b';
+    const kSuffixPattern =
+        `u8\\b|u32\\b|u64\\b|i8\\b|i32\\b|i64\\b|f16\\b|f32\\b`;
     const kIdentifierPattern = '[A-Za-z]\\w*';
 
     const rescape = (s) => s.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
@@ -668,8 +669,9 @@ export class NNotepad {
       // Common token patterns
       ws: /[ \t\r\n]*/,
       string: /"(?:[^\\\n\r"]|\\.)*"|'(?:[^\\\n\r']|\\.)*'/,
-      number: /NaN|Infinity|-Infinity|-?\d+(\.\d+)?([eE]-?\d+)?/,
-      suffix: /u8|u32|u64|i8|i32|i64|f16|f32/,
+      number: /NaN\b|Infinity\b|-Infinity\b|-?\d+(\.\d+)?([eE]-?\d+)?/,
+      boolean: /true\b|false\b/,
+      suffix: /u8\b|u32\b|u64\b|i8\b|i32\b|i64\b|f16\b|f32\b/,
       identifier: /[A-Za-z]\w*/,
 
       tokenizer: {
@@ -698,7 +700,7 @@ export class NNotepad {
           ['@string', 'string'],
 
           // Boolean
-          [/true|false/, 'keyword'],
+          ['@boolean', 'keyword'],
 
           // Dictionary
           [/{/, '@brackets', '@dict'],

--- a/nnotepad/js/tests.js
+++ b/nnotepad/js/tests.js
@@ -45,11 +45,31 @@ async function test(expr, expected) {
   }
 }
 
+async function testThrows(expr) {
+  try {
+    const [builderFunc] = NNotepad.makeBuilderFunction(expr);
+    const result = await NNotepad.execBuilderFunction('cpu', builderFunc);
+    Harness.error(`failed: ${expr} - expected to throw`);
+  } catch (ex) {
+    Harness.ok(`ok: ${expr}`);
+  }
+}
+
 // ============================================================
 // Test Cases
 // ============================================================
 
 document.addEventListener('DOMContentLoaded', async (e) => {
+  Harness.section('Numbers');
+  await test('125', {dataType: 'float32', shape: [], buffer: [125]});
+  await test('-125', {dataType: 'float32', shape: [], buffer: [-125]});
+  await test('1.25', {dataType: 'float32', shape: [], buffer: [1.25]});
+  await test('1.25e2', {dataType: 'float32', shape: [], buffer: [125]});
+  await test('125e-2', {dataType: 'float32', shape: [], buffer: [1.25]});
+  await test('Infinity', {dataType: 'float32', shape: [], buffer: [Infinity]});
+  await test('-Infinity', {dataType: 'float32', shape: [], buffer: [-Infinity]});
+  await test('NaN', {dataType: 'float32', shape: [], buffer: [NaN]});
+
   Harness.section('Operators');
   await test('1 + 2', {dataType: 'float32', shape: [], buffer: [3]});
   await test('2 * 3', {dataType: 'float32', shape: [], buffer: [6]});
@@ -148,6 +168,16 @@ document.addEventListener('DOMContentLoaded', async (e) => {
   await test(
       `concat([[1,2],[3,4]], 0)`,
       {dataType: 'float32', shape: [4], buffer: [1, 2, 3, 4]});
+  await test(
+      `trueblue = 123  (trueblue) + 1`,
+      {dataType: 'float32', shape: [], buffer: [124]});
+  await test(
+      `InfinityGauntlet = 123  (InfinityGauntlet) + 1`,
+      {dataType: 'float32', shape: [], buffer: [124]});
+  await test(
+      `NaNBread = 123  (NaNBread) + 1`,
+      {dataType: 'float32', shape: [], buffer: [124]});
+  await testThrows(`123u88`);
   // await test(`input = [[[1,2],[3,4]],[[5,6],[7,8]]]  weight =
   // [[[1,2],[1,2],[1,2],[1,2]]]  rweight = [[[1],[1],[1],[1]]]  lstm(input,
   // weight, rweight, 2, 1)`, {});

--- a/nnotepad/js/tests.js
+++ b/nnotepad/js/tests.js
@@ -48,7 +48,7 @@ async function test(expr, expected) {
 async function testThrows(expr) {
   try {
     const [builderFunc] = NNotepad.makeBuilderFunction(expr);
-    const result = await NNotepad.execBuilderFunction('cpu', builderFunc);
+    await NNotepad.execBuilderFunction('cpu', builderFunc);
     Harness.error(`failed: ${expr} - expected to throw`);
   } catch (ex) {
     Harness.ok(`ok: ${expr}`);
@@ -67,7 +67,8 @@ document.addEventListener('DOMContentLoaded', async (e) => {
   await test('1.25e2', {dataType: 'float32', shape: [], buffer: [125]});
   await test('125e-2', {dataType: 'float32', shape: [], buffer: [1.25]});
   await test('Infinity', {dataType: 'float32', shape: [], buffer: [Infinity]});
-  await test('-Infinity', {dataType: 'float32', shape: [], buffer: [-Infinity]});
+  await test(
+      '-Infinity', {dataType: 'float32', shape: [], buffer: [-Infinity]});
   await test('NaN', {dataType: 'float32', shape: [], buffer: [NaN]});
 
   Harness.section('Operators');


### PR DESCRIPTION
Ensure that some syntax elements - special numbers, booleans, type suffixes - are followed by word breaks. This prevents surprising parsing of things like "trueblue" as a boolean followed by an identifier instead of just an identifier.