### PR TITLE
Remove platform-specific layout selection code

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -518,18 +518,11 @@ export function permuteData(array, dims, axes) {
 }
 
 export function getDefaultLayout(deviceType) {
-  const userAgent = navigator.userAgent;
-  if (userAgent.indexOf('Linux') != -1 || userAgent.indexOf('Android') != -1 ||
-      userAgent.indexOf('CrOS') != -1) {
+  if (deviceType.indexOf('cpu') != -1) {
     return 'nhwc';
-  } else {
-    // Windows or Mac platform.
-    if (deviceType.indexOf('cpu') != -1) {
-      return 'nhwc';
-    } else if (deviceType.indexOf('gpu') != -1 ||
-               deviceType.indexOf('npu') != -1) {
-      return 'nchw';
-    }
+  } else if (deviceType.indexOf('gpu') != -1 ||
+             deviceType.indexOf('npu') != -1) {
+    return 'nchw';
   }
 }
 


### PR DESCRIPTION
The TFLite backend in Chromium supports either input layout. This heuristic for detecting whether or not this backend is being used can be removed as it now hinders testing.