### PR TITLE
Fix #288 Add empty shape for 0-D scalar constant / scalar input

### DIFF
--- a/code/samples/mul_add.js
+++ b/code/samples/mul_add.js
@@ -3,7 +3,7 @@ const context = await navigator.ml.createContext();
 const builder = new MLGraphBuilder(context);
 // 1. Create a computational graph 'C = 0.2 * A + B'.
 const constant = builder.constant(
-    {dataType: 'float32'}, new Float32Array([0.2]));
+    {dataType: 'float32', shape: []}, new Float32Array([0.2]));
 const A = builder.input('A', desc);
 const B = builder.input('B', desc);
 const C = builder.add(builder.mul(A, constant), B);

--- a/nnotepad/js/nnotepad.js
+++ b/nnotepad/js/nnotepad.js
@@ -447,8 +447,9 @@ export class NNotepad {
 
     function serializeScalar(number, dataType) {
       const ctor = WebNNUtil.dataTypeToBufferType(dataType);
-      return `_.constant({dataType:"${dataType}"}, new ${ctor.name}([${
-        Util.stringifyNumber(number, dataType)}]))`;
+      // building a 0-D scalar input with empty shape
+      return `_.constant({dataType:"${dataType}", dimensions: [], shape: []},
+      new ${ctor.name}([${Util.stringifyNumber(number, dataType)}]))`;
     }
     function suffixToDataType(suffix) {
       return {


### PR DESCRIPTION
Fix #288

@Honry @huningxin PTAL

Question to @huningxin , shall we change the code sample below in spec as well?

`const constant = builder.constant(operandType.dataType, 0.2);`
https://www.w3.org/TR/webnn/#api-mlcontext-compute-examples 