### PR TITLE
Fix MLTensorUsage is undefined issue

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -306,8 +306,11 @@ export function getUrlParams() {
 
 export async function isWebNN() {
   if (typeof MLGraphBuilder !== 'undefined') {
-    const context = await navigator.ml.createContext();
-    return !context.tf;
+    if (typeof MLTensorUsage == 'undefined') {
+      // Polyfill MLTensorUsage to make it compatible with old version of Chrome.
+      window.MLTensorUsage = {WEBGPU_INTEROP: 1, READ: 2, WRITE: 4};
+    }
+    return true;
   } else {
     return false;
   }

--- a/common/utils.js
+++ b/common/utils.js
@@ -306,8 +306,8 @@ export function getUrlParams() {
 
 export async function isWebNN() {
   if (typeof MLGraphBuilder !== 'undefined') {
+    // Polyfill MLTensorUsage to make it compatible with old version of Chrome.
     if (typeof MLTensorUsage == 'undefined') {
-      // Polyfill MLTensorUsage to make it compatible with old version of Chrome.
       window.MLTensorUsage = {WEBGPU_INTEROP: 1, READ: 2, WRITE: 4};
     }
     return true;

--- a/nnotepad/js/nnotepad.js
+++ b/nnotepad/js/nnotepad.js
@@ -52,7 +52,8 @@ class WebNNUtil {
       dataType: isShapeMethod ? operand.dataType() : operand.dataType,
       dimensions: isShapeMethod ? operand.shape() : operand.shape,
       shape: isShapeMethod ? operand.shape() : operand.shape,
-      usage: MLTensorUsage.READ,
+      usage: typeof MLTensorUsage == 'undefined' ?
+          undefined : MLTensorUsage.READ,
       readable: true,
     };
     const tensor = await context.createTensor(desc);


### PR DESCRIPTION
Chromium has removed MLTensorUsage at https://chromium-review.googlesource.com/c/chromium/src/+/6015318, this would cause `the MLTensorUsage is undefined` issue in latest Chrome Canary. If we remove it directly the old version of Chrome will fail.

So in the PR we polyfill the MLTensorUsage to make it compatible.