### PR TITLE
Fix exception from splice

### DIFF
--- a/face_recognition/facenet_nchw.js
+++ b/face_recognition/facenet_nchw.js
@@ -269,7 +269,7 @@ export class FaceNetNchw {
     const averagePool = this.builder_.averagePool2d(await block8_6);
     // Use reshape to implement squeeze(averagePool, {axes: [2, 3]});
     const squeezed_shape = typeof averagePool.shape === 'function' ?
-        averagePool.shape() : averagePool.shape;
+        averagePool.shape() : [...averagePool.shape];
     squeezed_shape.splice(2, 2);
     const squeeze = this.builder_.reshape(averagePool, squeezed_shape);
     const gemm = await this.buildGemm_(squeeze);

--- a/nsnet2/nsnet2.js
+++ b/nsnet2/nsnet2.js
@@ -59,7 +59,7 @@ export class NSNet2 {
         {bias: bias194, recurrentBias: recurrentBias194, initialHiddenState: initialState92, returnSequence: true});
     // Use reshape to implement squeeze(gru93, {axes: [1]});
     const isShapeMethod = typeof gru93.shape === 'function';
-    const squeeze95Shape = isShapeMethod ? gru93.shape() : gru93.shape;
+    const squeeze95Shape = isShapeMethod ? gru93.shape() : [...gru93.shape];
     squeeze95Shape.splice(1, 1);
     const squeeze95 = this.builder_.reshape(gru93, squeeze95Shape);
     const initialState155 = this.builder_.input('initialState155', initialStateDesc);
@@ -90,7 +90,7 @@ export class NSNet2 {
     const [gru157, gru156] = this.builder_.gru(squeeze95, weight212, recurrentWeight213, frames, this.hiddenSize,
         {bias: bias214, recurrentBias: recurrentBias214, initialHiddenState: initialState155, returnSequence: true});
     // Use reshape to implement squeeze(gru156, {axes: [1]});
-    const squeeze158Shape = isShapeMethod ? gru156.shape() : gru156.shape;
+    const squeeze158Shape = isShapeMethod ? gru156.shape() : [...gru156.shape];
     squeeze158Shape.splice(1, 1);
     const squeeze158 = this.builder_.reshape(gru156, squeeze158Shape);
     const transpose159 = this.builder_.transpose(squeeze158, {permutation: [1, 0, 2]});


### PR DESCRIPTION
MLOperand.shape now returns a read-only Array,
this would cause splice throws TypeError because it is trying to modify a read-only Array.

Fix this issue by creating a copy from the read-only Array.