### PR TITLE
NNotepad: Pass buffers rather than views when building constants

### DIFF
--- a/nnotepad/js/nnotepad.js
+++ b/nnotepad/js/nnotepad.js
@@ -563,7 +563,7 @@ export class NNotepad {
       const ctor = WebNNUtil.dataTypeToBufferType(dataType);
       // building a 0-D scalar input with empty shape
       return `_.constant({dataType:"${dataType}", dimensions: [], shape: []},
-      new ${ctor.name}([${Util.stringifyNumber(number, dataType)}]))`;
+      new ${ctor.name}([${Util.stringifyNumber(number, dataType)}]).buffer)`;
     }
     function suffixToDataType(suffix) {
       return {
@@ -603,7 +603,8 @@ export class NNotepad {
       return `_.constant({dataType: "${dataType}", dimensions: ${
         Util.stringify(shape)}, shape: ${
         Util.stringify(shape)}}, new ${ctor.name}([${
-        elements.map((n) => Util.stringifyNumber(n, dataType)).join(',')}]))`;
+        elements.map((n) => Util.stringifyNumber(n, dataType)).join(',')
+      }]).buffer)`;
     }
 
     function serializeArray(array, argumentType) {
@@ -629,7 +630,8 @@ export class NNotepad {
         return `_.constant({dataType: "${dataType.value}", dimensions: ${
           Util.stringify(dims)}, shape: ${
           Util.stringify(dims)}}, new ${
-          ctor.name}(await Util.loadBuffer(${Util.stringify(url.value)})))`;
+          ctor.name}(await Util.loadBuffer(${
+          Util.stringify(url.value)})).buffer)`;
       }
 
       if (name === 'zeros') {
@@ -646,7 +648,7 @@ export class NNotepad {
         return `_.constant({dataType: "${dataType.value}", dimensions: ${
           Util.stringify(dims)}, shape: ${
           Util.stringify(dims)}}, new ${
-          ctor.name}(${len}))`;
+          ctor.name}(${len}).buffer)`;
       }
 
       return `_.${name}(${


### PR DESCRIPTION
When building constants, either a raw ArrayBuffer can be passed or a view type like Float32Array. In the latter case the data type and view type must match; e.g. if dataType is "int8", a Uint8Array must be passed.

Chromium is in the process of rolling out native Float16Array support, but currently the WebNN prototype implementation[1] requires passing a Uint16Array if the data type is "float16". NNotepad utilizes this workaround if native Float16Array is not present. But if it *is* present, it passes a native Float16Array and Chromium throws.

Until things settle, have NNotepad's constant() builder just pass the underlying buffer rather than view, which bypasses this check. This change can be reverted at some point in the future, but is harmless to continue using this workaround.

1: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/ml/webnn/ml_graph_utils.cc;l=92