### PR TITLE
NNotepad: Update generated docs (and docs generator)

### DIFF
--- a/nnotepad/bin/makedocs
+++ b/nnotepad/bin/makedocs
@@ -17,17 +17,48 @@ with open('res/docs.html', 'w', encoding='utf-8', errors='xmlcharrefreplace') as
 
   DO NOT EDIT.
 
-  Edit README.md instead, then run: ./makedocs
+  Edit README.md instead, then run: bin/makedocs
 
 -->
 <style>
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 200;
+  src: url("../../common/css/fonts/poppins/poppins-v15-latin-200.woff2")
+      format("woff2");
+}
+
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../../common/css/fonts/poppins/poppins-v15-latin-regular.woff2")
+      format("woff2");
+}
+
+@font-face {
+  font-display: swap;
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 200;
+  src: url('../../common/css/fonts/jetbrains-mono/jetbrains-mono-v18-latin-200.woff2') format('woff2');
+}
+
+@font-face {
+  font-display: swap;
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: url('../../common/css/fonts/jetbrains-mono/jetbrains-mono-v18-latin-regular.woff2') format('woff2');
+}
 body {
-  font-family: sans-serif;
   font-size: 16px;
   line-height: 30px;
+  font-family: "Poppins", "Consolas", "Lucida Console", monospace;
 }
 code {
-  font-family: "Consolas", "Lucida Console", monospace;
+  font-family: "JetBrains Mono", "Consolas", "Lucida Console", monospace;
 }
 code {
   display: inline-block;
@@ -43,8 +74,9 @@ pre code {
 }
 pre {
   background-color: #eee;
-  border-radius: 1lh;
+  border-radius: 10px;
   padding: 1lh;
+  font-family: "JetBrains Mono", "Consolas", "Lucida Console", monospace;
 }
 </style>
 

--- a/nnotepad/res/docs.html
+++ b/nnotepad/res/docs.html
@@ -7,7 +7,7 @@
 
   DO NOT EDIT.
 
-  Edit README.md instead, then run: ./makedocs
+  Edit README.md instead, then run: bin/makedocs
 
 -->
 <style>
@@ -99,10 +99,10 @@ matmul(A,B)
 <p>Functions and operators are turned into <a href="https://webmachinelearning.github.io/webnn/#mlgraphbuilder"><code>MLGraphBuilder</code></a> method calls.</p>
 <p>Array literals (<code>[...]</code>) and number literals (<code>12.34</code>) are interpreted contextually:</p>
 <ul>
-<li>In assignments, they are intepreted as tensor/scalar constant <a href="https://webmachinelearning.github.io/webnn/#mloperand"><code>MLOperand</code></a>s, e.g. <code>alpha = 12.34</code> or <code>T = [1,2,3,4]</code>.</li>
-<li>In most function calls, they are interpreted as tensor/scalar constant <a href="https://webmachinelearning.github.io/webnn/#mloperand"><code>MLOperand</code></a>s, e.g. <code>neg(123)</code> or <code>neg([1,2,3])</code>.</li>
-<li>In some function calls, they are interpreted as arrays/numbers for some positional parameters, e.g. <code>concat([A,B,C],0)</code>. This includes: <a href="https://webmachinelearning.github.io/webnn/#dom-mlgraphbuilder-concat"><code>concat()</code></a>, <a href="https://webmachinelearning.github.io/webnn/#dom-mlgraphbuilder-expand"><code>expand()</code></a>, <a href="https://webmachinelearning.github.io/webnn/#dom-mlgraphbuilder-pad"><code>pad()</code></a>, <a href="https://webmachinelearning.github.io/webnn/#dom-mlgraphbuilder-reshape"><code>reshape()</code></a>, <a href="https://webmachinelearning.github.io/webnn/#dom-mlgraphbuilder-slice"><code>slice()</code></a>, <a href="https://webmachinelearning.github.io/webnn/#dom-mlgraphbuilder-split"><code>split()</code></a>.</li>
-<li>In dictionaries, they are interpreted as arrays/numbers, e.g. <code>linear(123, {alpha: 456, beta: 789})</code> or <code>transpose(T, {permutation: [0,2,1]})</code>. To pass a tensor/scalar constant in a dictionary, use a variable or wrap it in <a href="https://webmachinelearning.github.io/webnn/#dom-mlgraphbuilder-identity"><code>identity()</code></a> e.g. <code>gemm(A, B, {c:identity([4])})</code> or <code>gemm(A, B, {c:identity(4)})</code>.</li>
+<li>In assignments, they are intepreted as tensor/scalar constants <a href="https://webmachinelearning.github.io/webnn/#mloperand"><code>MLOperand</code></a>s, e.g. <code>alpha = 12.34</code> (scalar) or <code>T = [1,2,3,4]</code> (tensor).</li>
+<li>As arguments in function calls, they are interpreted depending on the argument definition, e.g. <code>neg(123)</code> (scalar), <code>neg([1,2,3])</code> (tensor), <code>concat([A,B,C],0)</code> (number).</li>
+<li>In options dictionaries inside function calls, they are interpreted depending on the dictionary definition. e.g. <code>linear(123, {alpha: 456, beta: 789})</code> (numbers), <code>transpose(T, {permutation: [0,2,1]})</code> (array of numbers), <code>gemm(A, B, {c: 123})</code> (scalar), <code>gemm(A, B, {c: [123]})</code> (tensor).</li>
+<li>In dictionaries outside of function calls, they are interpreted as arrays/numbers, e.g. <code>options = {alpha: 456, beta: 789})</code>. To pass a tensor/scalar constant in a dictionary, use a variable or wrap it in <a href="https://webmachinelearning.github.io/webnn/#dom-mlgraphbuilder-identity"><code>identity()</code></a> e.g. <code>options = {c:identity(4)}  gemm(A, B, options)</code>.</li>
 </ul>
 <p>The default <a href="https://webmachinelearning.github.io/webnn/#enumdef-mloperanddatatype">data type</a> for scalars and tensors is <a href="https://webmachinelearning.github.io/webnn/#dom-mloperanddatatype-float32"><code>float32</code></a>. To specify a different data type, suffix with one of <code>i8</code>, <code>u8</code>, <code>i32</code>, <code>u32</code>, <code>i64</code>, <code>u64</code>, <code>f16</code>, <code>f32</code>, e.g. <code>123i8</code> or <code>[1,2,3]u32</code>.</p>
 <h1>Helpers</h1>


### PR DESCRIPTION
res/docs.html is generated automatically from README.md by bin/makedocs but fell out of sync; some changes were made directly to res/docs.html and some changes were made to README.md without regenerating the docs. Ooops!

Sync things up again.