### PR TITLE
NNotepad: Parse the IDL to determine argument types

### DIFF
--- a/nnotepad/js/index.js
+++ b/nnotepad/js/index.js
@@ -15,6 +15,8 @@ document.addEventListener('DOMContentLoaded', async (e) => {
     console.warn(ex);
   }
 
+  await NNotepad.asyncInit();
+
   NNotepad.addMonacoLanguage(monaco);
   const editor = monaco.editor.create($('#input'), {
     value: inputValue,

--- a/nnotepad/js/tests.js
+++ b/nnotepad/js/tests.js
@@ -60,6 +60,8 @@ async function testThrows(expr) {
 // ============================================================
 
 document.addEventListener('DOMContentLoaded', async (e) => {
+  NNotepad.asyncInit();
+
   Harness.section('Numbers');
   await test('125', {dataType: 'float32', shape: [], buffer: [125]});
   await test('-125', {dataType: 'float32', shape: [], buffer: [-125]});

--- a/nnotepad/res/webnn.idl
+++ b/nnotepad/res/webnn.idl
@@ -1,0 +1,553 @@
+interface mixin NavigatorML {
+  [SecureContext, SameObject] readonly attribute ML ml;
+};
+Navigator includes NavigatorML;
+WorkerNavigator includes NavigatorML;
+
+enum MLDeviceType {
+  "cpu",
+  "gpu",
+  "npu"
+};
+
+enum MLPowerPreference {
+  "default",
+  "high-performance",
+  "low-power"
+};
+
+dictionary MLContextOptions {
+  MLDeviceType deviceType = "cpu";
+  MLPowerPreference powerPreference = "default";
+};
+
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface ML {
+  Promise<MLContext> createContext(optional MLContextOptions options = {});
+  Promise<MLContext> createContext(GPUDevice gpuDevice);
+};
+
+typedef record<USVString, ArrayBufferView> MLNamedArrayBufferViews;
+
+dictionary MLComputeResult {
+  MLNamedArrayBufferViews inputs;
+  MLNamedArrayBufferViews outputs;
+};
+
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface MLContext {
+  Promise<MLComputeResult> compute(
+      MLGraph graph, MLNamedArrayBufferViews inputs, MLNamedArrayBufferViews outputs);
+};
+
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface MLGraph {};
+
+enum MLInputOperandLayout {
+  "nchw",
+  "nhwc"
+};
+
+enum MLOperandDataType {
+  "float32",
+  "float16",
+  "int32",
+  "uint32",
+  "int64",
+  "uint64",
+  "int8",
+  "uint8"
+};
+
+dictionary MLOperandDescriptor {
+  required MLOperandDataType dataType;
+  sequence<[EnforceRange] unsigned long> dimensions = [];
+};
+
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface MLOperand {
+  MLOperandDataType dataType();
+  sequence<unsigned long> shape();
+};
+
+typedef (bigint or unrestricted double) MLNumber;
+
+typedef record<USVString, MLOperand> MLNamedOperands;
+
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface MLGraphBuilder {
+  // Construct the graph builder from the context.
+  constructor(MLContext context);
+
+  // Create an operand for a graph input.
+  MLOperand input(USVString name, MLOperandDescriptor descriptor);
+
+  // Create an operand for a graph constant.
+  MLOperand constant(MLOperandDescriptor descriptor, ArrayBufferView bufferView);
+
+  // Create a scalar operand from the specified number of the specified type.
+  MLOperand constant(MLOperandDataType type, MLNumber value);
+
+  // Compile the graph up to the specified output operands asynchronously.
+  Promise<MLGraph> build(MLNamedOperands outputs);
+};
+
+dictionary MLArgMinMaxOptions {
+  boolean keepDimensions = false;
+  MLOperandDataType outputDataType = "int32";
+};
+
+partial interface MLGraphBuilder {
+  MLOperand argMin(MLOperand input, [EnforceRange] unsigned long axis,
+                   optional MLArgMinMaxOptions options = {});
+  MLOperand argMax(MLOperand input, [EnforceRange] unsigned long axis,
+                   optional MLArgMinMaxOptions options = {});
+};
+
+dictionary MLBatchNormalizationOptions {
+  MLOperand scale;
+  MLOperand bias;
+  [EnforceRange] unsigned long axis = 1;
+  double epsilon = 1e-5;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand batchNormalization(MLOperand input, MLOperand mean, MLOperand variance,
+                               optional MLBatchNormalizationOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand cast(MLOperand input, MLOperandDataType type);
+};
+
+dictionary MLClampOptions {
+  MLNumber minValue;
+  MLNumber maxValue;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand clamp(MLOperand input, optional MLClampOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand concat(sequence<MLOperand> inputs, [EnforceRange] unsigned long axis);
+};
+
+enum MLConv2dFilterOperandLayout {
+  "oihw",
+  "hwio",
+  "ohwi",
+  "ihwo"
+};
+
+dictionary MLConv2dOptions {
+  sequence<[EnforceRange] unsigned long> padding;
+  sequence<[EnforceRange] unsigned long> strides;
+  sequence<[EnforceRange] unsigned long> dilations;
+  [EnforceRange] unsigned long groups = 1;
+  MLInputOperandLayout inputLayout = "nchw";
+  MLConv2dFilterOperandLayout filterLayout = "oihw";
+  MLOperand bias;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand conv2d(MLOperand input,
+                   MLOperand filter,
+                   optional MLConv2dOptions options = {});
+};
+
+enum MLConvTranspose2dFilterOperandLayout {
+  "iohw",
+  "hwoi",
+  "ohwi"
+};
+
+dictionary MLConvTranspose2dOptions {
+  sequence<[EnforceRange] unsigned long> padding;
+  sequence<[EnforceRange] unsigned long> strides;
+  sequence<[EnforceRange] unsigned long> dilations;
+  sequence<[EnforceRange] unsigned long> outputPadding;
+  sequence<[EnforceRange] unsigned long> outputSizes;
+  [EnforceRange] unsigned long groups = 1;
+  MLInputOperandLayout inputLayout = "nchw";
+  MLConvTranspose2dFilterOperandLayout filterLayout = "iohw";
+  MLOperand bias;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand convTranspose2d(MLOperand input, MLOperand filter,
+                            optional MLConvTranspose2dOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand add(MLOperand a, MLOperand b);
+  MLOperand sub(MLOperand a, MLOperand b);
+  MLOperand mul(MLOperand a, MLOperand b);
+  MLOperand div(MLOperand a, MLOperand b);
+  MLOperand max(MLOperand a, MLOperand b);
+  MLOperand min(MLOperand a, MLOperand b);
+  MLOperand pow(MLOperand a, MLOperand b);
+};
+
+partial interface MLGraphBuilder {
+  MLOperand equal(MLOperand a, MLOperand b);
+  MLOperand greater(MLOperand a, MLOperand b);
+  MLOperand greaterOrEqual(MLOperand a, MLOperand b);
+  MLOperand lesser(MLOperand a, MLOperand b);
+  MLOperand lesserOrEqual(MLOperand a, MLOperand b);
+  MLOperand logicalNot(MLOperand a);
+};
+
+partial interface MLGraphBuilder {
+  MLOperand abs(MLOperand input);
+  MLOperand ceil(MLOperand input);
+  MLOperand cos(MLOperand input);
+  MLOperand erf(MLOperand input);
+  MLOperand exp(MLOperand input);
+  MLOperand floor(MLOperand input);
+  MLOperand identity(MLOperand input);
+  MLOperand log(MLOperand input);
+  MLOperand neg(MLOperand input);
+  MLOperand reciprocal(MLOperand input);
+  MLOperand sin(MLOperand input);
+  MLOperand sqrt(MLOperand input);
+  MLOperand tan(MLOperand input);
+};
+
+dictionary MLEluOptions {
+  double alpha = 1;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand elu(MLOperand input, optional MLEluOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand expand(MLOperand input, sequence<[EnforceRange] unsigned long> newShape);
+};
+
+dictionary MLGatherOptions {
+  [EnforceRange] unsigned long axis = 0;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand gather(MLOperand input,
+                   MLOperand indices,
+                   optional MLGatherOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand gelu(MLOperand input);
+};
+
+dictionary MLGemmOptions {
+  MLOperand c;
+  double alpha = 1.0;
+  double beta = 1.0;
+  boolean aTranspose = false;
+  boolean bTranspose = false;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand gemm(MLOperand a, MLOperand b, optional MLGemmOptions options = {});
+};
+
+enum MLGruWeightLayout {
+  "zrn",  // update-reset-new gate ordering
+  "rzn"   // reset-update-new gate ordering
+};
+
+enum MLRecurrentNetworkActivation {
+  "relu",
+  "sigmoid",
+  "tanh"
+};
+
+enum MLRecurrentNetworkDirection {
+  "forward",
+  "backward",
+  "both"
+};
+
+dictionary MLGruOptions {
+  MLOperand bias;
+  MLOperand recurrentBias;
+  MLOperand initialHiddenState;
+  boolean resetAfter = true;
+  boolean returnSequence = false;
+  MLRecurrentNetworkDirection direction = "forward";
+  MLGruWeightLayout layout = "zrn";
+  sequence<MLRecurrentNetworkActivation> activations;
+};
+
+partial interface MLGraphBuilder {
+  sequence<MLOperand> gru(MLOperand input,
+                          MLOperand weight,
+                          MLOperand recurrentWeight,
+                          [EnforceRange] unsigned long steps,
+                          [EnforceRange] unsigned long hiddenSize,
+                          optional MLGruOptions options = {});
+};
+
+dictionary MLGruCellOptions {
+  MLOperand bias;
+  MLOperand recurrentBias;
+  boolean resetAfter = true;
+  MLGruWeightLayout layout = "zrn";
+  sequence<MLRecurrentNetworkActivation> activations;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand gruCell(MLOperand input,
+                    MLOperand weight,
+                    MLOperand recurrentWeight,
+                    MLOperand hiddenState,
+                    [EnforceRange] unsigned long hiddenSize,
+                    optional MLGruCellOptions options = {});
+};
+
+dictionary MLHardSigmoidOptions {
+  double alpha = 0.2;
+  double beta = 0.5;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand hardSigmoid(MLOperand input, optional MLHardSigmoidOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand hardSwish(MLOperand input);
+};
+
+dictionary MLInstanceNormalizationOptions {
+  MLOperand scale;
+  MLOperand bias;
+  double epsilon = 1e-5;
+  MLInputOperandLayout layout = "nchw";
+};
+
+partial interface MLGraphBuilder {
+  MLOperand instanceNormalization(MLOperand input,
+                                  optional MLInstanceNormalizationOptions options = {});
+};
+
+dictionary MLLayerNormalizationOptions {
+  MLOperand scale;
+  MLOperand bias;
+  sequence<[EnforceRange] unsigned long> axes;
+  double epsilon = 1e-5;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand layerNormalization(MLOperand input,
+                               optional MLLayerNormalizationOptions options = {});
+};
+
+dictionary MLLeakyReluOptions {
+  double alpha = 0.01;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand leakyRelu(MLOperand input, optional MLLeakyReluOptions options = {});
+};
+
+dictionary MLLinearOptions {
+  double alpha = 1;
+  double beta = 0;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand linear(MLOperand input, optional MLLinearOptions options = {});
+};
+
+enum MLLstmWeightLayout {
+  "iofg", // input-output-forget-cell gate ordering
+  "ifgo"  // input-forget-cell-output gate ordering
+};
+
+dictionary MLLstmOptions {
+  MLOperand bias;
+  MLOperand recurrentBias;
+  MLOperand peepholeWeight;
+  MLOperand initialHiddenState;
+  MLOperand initialCellState;
+  boolean returnSequence = false;
+  MLRecurrentNetworkDirection direction = "forward";
+  MLLstmWeightLayout layout = "iofg";
+  sequence<MLRecurrentNetworkActivation> activations;
+};
+
+partial interface MLGraphBuilder {
+  sequence<MLOperand> lstm(MLOperand input,
+                           MLOperand weight,
+                           MLOperand recurrentWeight,
+                           [EnforceRange] unsigned long steps,
+                           [EnforceRange] unsigned long hiddenSize,
+                           optional MLLstmOptions options = {});
+};
+
+dictionary MLLstmCellOptions {
+  MLOperand bias;
+  MLOperand recurrentBias;
+  MLOperand peepholeWeight;
+  MLLstmWeightLayout layout = "iofg";
+  sequence<MLRecurrentNetworkActivation> activations;
+};
+
+partial interface MLGraphBuilder {
+  sequence<MLOperand> lstmCell(MLOperand input,
+                               MLOperand weight,
+                               MLOperand recurrentWeight,
+                               MLOperand hiddenState,
+                               MLOperand cellState,
+                               [EnforceRange] unsigned long hiddenSize,
+                               optional MLLstmCellOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand matmul(MLOperand a, MLOperand b);
+};
+
+enum MLPaddingMode {
+  "constant",
+  "edge",
+  "reflection",
+  "symmetric"
+};
+
+dictionary MLPadOptions {
+  MLPaddingMode mode = "constant";
+  MLNumber value = 0;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand pad(MLOperand input,
+                sequence<[EnforceRange] unsigned long> beginningPadding,
+                sequence<[EnforceRange] unsigned long> endingPadding,
+                optional MLPadOptions options = {});
+};
+
+enum MLRoundingType {
+  "floor",
+  "ceil"
+};
+
+dictionary MLPool2dOptions {
+  sequence<[EnforceRange] unsigned long> windowDimensions;
+  sequence<[EnforceRange] unsigned long> padding;
+  sequence<[EnforceRange] unsigned long> strides;
+  sequence<[EnforceRange] unsigned long> dilations;
+  MLInputOperandLayout layout = "nchw";
+  MLRoundingType roundingType = "floor";
+  sequence<[EnforceRange] unsigned long> outputSizes;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand averagePool2d(MLOperand input, optional MLPool2dOptions options = {});
+  MLOperand l2Pool2d(MLOperand input, optional MLPool2dOptions options = {});
+  MLOperand maxPool2d(MLOperand input, optional MLPool2dOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand prelu(MLOperand input, MLOperand slope);
+};
+
+dictionary MLReduceOptions {
+  sequence<[EnforceRange] unsigned long> axes;
+  boolean keepDimensions = false;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand reduceL1(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceL2(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceLogSum(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceLogSumExp(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceMax(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceMean(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceMin(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceProduct(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceSum(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceSumSquare(MLOperand input, optional MLReduceOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand relu(MLOperand input);
+};
+
+enum MLInterpolationMode {
+  "nearest-neighbor",
+  "linear"
+};
+
+dictionary MLResample2dOptions {
+  MLInterpolationMode mode = "nearest-neighbor";
+  sequence<float> scales;
+  sequence<[EnforceRange] unsigned long> sizes;
+  sequence<[EnforceRange] unsigned long> axes;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand resample2d(MLOperand input, optional MLResample2dOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand reshape(MLOperand input, sequence<[EnforceRange] unsigned long> newShape);
+};
+
+partial interface MLGraphBuilder {
+  MLOperand sigmoid(MLOperand input);
+};
+
+partial interface MLGraphBuilder {
+  MLOperand slice(MLOperand input,
+                  sequence<[EnforceRange] unsigned long> starts,
+                  sequence<[EnforceRange] unsigned long> sizes);
+};
+
+partial interface MLGraphBuilder {
+  MLOperand softmax(MLOperand input, unsigned long axis);
+};
+
+partial interface MLGraphBuilder {
+  MLOperand softplus(MLOperand input);
+};
+
+partial interface MLGraphBuilder {
+  MLOperand softsign(MLOperand input);
+};
+
+dictionary MLSplitOptions {
+  [EnforceRange] unsigned long axis = 0;
+};
+
+partial interface MLGraphBuilder {
+  sequence<MLOperand> split(
+      MLOperand input,
+      ([EnforceRange] unsigned long or sequence<[EnforceRange] unsigned long>) splits,
+      optional MLSplitOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand tanh(MLOperand input);
+};
+
+dictionary MLTransposeOptions {
+  sequence<[EnforceRange] unsigned long> permutation;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand transpose(MLOperand input, optional MLTransposeOptions options = {});
+};
+
+dictionary MLTriangularOptions {
+  boolean upper = true;
+  [EnforceRange] long diagonal = 0;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand triangular(MLOperand input, optional MLTriangularOptions options = {});
+};
+
+partial interface MLGraphBuilder {
+  MLOperand where(MLOperand condition, MLOperand trueValue, MLOperand falseValue);
+};

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "babel-eslint": "^8.0.3",
-    "monaco-editor": "^0.49.0"
+    "monaco-editor": "^0.49.0",
+    "webidl2": "^24.4.1"
   }
 }


### PR DESCRIPTION
To know how to parse argument and dictionary members - are they tensors or simple types? - the parser asks a WebNNUtil function. This function did the job by hardcoding a list of the special cases. This requires careful maintenance.

Update the code to bundle a copy of the WebIDL and parse it, instead. This uses webidl2.js, which is the same library used by Web Platform Tests for validating the IDL.

This will require updating the snapshot IDL as the spec evolves, but that's less specialized than tweaking the special JSON data and can potentially be automated.

Future work includes:

- Fetch the IDL from the Web Platform Tests repository, or some other CORS-friendly canonical resource.

- Use the parsed IDL to drive the Monaco editor, for better autocomplete.