### PR TITLE
NNotepad: Fix NPM module include for serving from github.io

### DIFF
--- a/nnotepad/js/nnotepad.js
+++ b/nnotepad/js/nnotepad.js
@@ -1,7 +1,7 @@
 /* global BigInt64Array, BigUint64Array, Float16Array */
 
 import {Util} from './util.js';
-import * as idl from 'webidl2';
+import * as idl from '../../node_modules/webidl2/index.js';
 
 // ============================================================
 // General Utilities


### PR DESCRIPTION
The Vite server used for local development will automagically rewrite NPM module references from script file imports, but when serving from github.io that fails. Oops!

Just use the explicit relative path to the webidl2 module.