### PR TITLE
NNotepad: Use CDN for webidl2.js

### DIFF
--- a/nnotepad/js/nnotepad.js
+++ b/nnotepad/js/nnotepad.js
@@ -1,7 +1,7 @@
 /* global BigInt64Array, BigUint64Array, Float16Array */
 
 import {Util} from './util.js';
-import * as idl from '../../node_modules/webidl2/index.js';
+import * as idl from 'https://cdn.jsdelivr.net/npm/webidl2@24.4.1/index.js';
 
 // ============================================================
 // General Utilities


### PR DESCRIPTION
The previous fix 97eee70 was insufficient because the gh-pages builder doesn't pull in NPM modules either. Oops! So just use a CDN, I guess.

The package.json reference can probably be dropped now, but I'm leaving it in for now.