### PR TITLE
Rename roundingType to outputShapeRounding for pool2d ops

### DIFF
--- a/nnotepad/res/webnn.idl
+++ b/nnotepad/res/webnn.idl
@@ -439,6 +439,7 @@ dictionary MLPool2dOptions {
   sequence<[EnforceRange] unsigned long> dilations;
   MLInputOperandLayout layout = "nchw";
   MLRoundingType roundingType = "floor";
+  MLRoundingType outputShapeRounding = "floor";
   sequence<[EnforceRange] unsigned long> outputSizes;
 };
 


### PR DESCRIPTION
Keep original roundingType name for a period of time to ensure backward compatibility.

Spec change: https://github.com/webmachinelearning/webnn/pull/770